### PR TITLE
Add text and image components

### DIFF
--- a/resources/boost/skills/slidewire-development/SKILL.md
+++ b/resources/boost/skills/slidewire-development/SKILL.md
@@ -6,7 +6,7 @@ metadata:
 
 # SlideWire Development
 
-Use this skill when working with `wendelladriel/slidewire`: creating new presentations, improving existing decks, adding navigation-friendly structure, or styling slides with themes, markdown, code, diagrams, and fragments.
+Use this skill when working with `wendelladriel/slidewire`: creating new presentations, improving existing decks, adding navigation-friendly structure, or styling slides with themes, text, images, markdown, code, diagrams, and fragments.
 
 ## Start with the SlideWire workflow
 
@@ -64,16 +64,88 @@ Strong defaults:
 - `<x-slidewire::slide>`: a single slide, with support for metadata like `theme`, `transition`, `transition-speed`, `auto-slide`, `auto-animate`, and background attributes.
 - `<x-slidewire::vertical-slide>`: groups slides into a vertical stack inside one horizontal column.
 - `<x-slidewire::fragment>`: reveals content progressively.
+- `<x-slidewire::text>`: semantic text wrapper with optional orientation and component-level animation hooks.
+- `<x-slidewire::image>`: native image wrapper with component-level animation hooks.
 - `<x-slidewire::markdown>`: renders markdown and highlighted code fences.
 - `<x-slidewire::code>`: renders highlighted code blocks directly.
 - `<x-slidewire::diagram>`: renders Mermaid diagrams.
 
 ### When to use each content component
 
+- Use `text` for semantic headings, paragraphs, inline text, vertical labels, or reusable animation-ready copy blocks.
+- Use `image` for native `<img>` output with SlideWire animation metadata.
 - Use `markdown` for narrative slides, bullets, and mixed prose/code.
 - Use `code` for tightly controlled code examples or language-specific snippets.
 - Use `diagram` for flows, architecture, and process explanations.
 - Use `fragment` for sequential reveals instead of overcrowding one slide.
+
+### Text component guidance
+
+Use `text` when you want semantic text output without hand-writing repeated animation and orientation attributes.
+
+Supported attributes:
+
+- `type`: `paragraph` (default), `inline`, `heading`
+- `orientation`: `horizontal` (default), `vertical`
+- `animation`
+- `animation-speed`
+- `class` and any other valid HTML attributes for the rendered tag
+
+Examples:
+
+```blade
+<x-slidewire::text type="heading" class="text-5xl font-semibold tracking-tight">
+    Product Launch
+</x-slidewire::text>
+```
+
+```blade
+<x-slidewire::text
+    type="heading"
+    orientation="vertical"
+    animation="slide-up"
+    animation-speed="slow"
+    class="text-4xl"
+>
+    Launch Day
+</x-slidewire::text>
+```
+
+Recommendations:
+
+- Prefer `heading` for prominent slide titles when `h2` semantics make sense.
+- Prefer `inline` for short labels embedded in richer layouts.
+- Use `orientation="vertical"` for side labels or editorial layouts, not long paragraphs.
+- Fall back to raw HTML when you need fully custom markup.
+
+### Image component guidance
+
+Use `image` when you want a normal `<img>` element with the same animation contract as other SlideWire content components.
+
+Supported attributes:
+
+- all standard image attributes like `src`, `alt`, `class`, `width`, `height`, `loading`, `decoding`, and `fetchpriority`
+- `animation`
+- `animation-speed`
+
+Example:
+
+```blade
+<x-slidewire::image
+    src="/images/product-shot.png"
+    alt="Product shot"
+    class="w-72 rounded-2xl shadow-2xl"
+    loading="lazy"
+    animation="pop"
+    animation-speed="default"
+/>
+```
+
+Recommendations:
+
+- Always provide meaningful `alt` text unless the image is purely decorative.
+- Keep sizing intentional with Tailwind classes or width/height attributes.
+- Use native image attributes directly instead of expecting PHP-side prop mapping.
 
 ## Structure slides for presentation flow
 
@@ -218,6 +290,31 @@ Recommendations:
 - Use `auto-animate` for before/after or transformation sequences with matching element IDs.
 - Use `auto-slide` sparingly for timed demos or kiosk-style decks.
 
+### Component-level animations
+
+`text` and `image` support element-level entry animations through `animation` and `animation-speed`.
+
+Supported names:
+
+- `fade`
+- `pop`
+- `zoom-in`
+- `zoom-out`
+- `slide-left`
+- `slide-right`
+- `slide-up`
+- `slide-down`
+- `blur`
+- `typewriter` (`text` only)
+
+Recommendations:
+
+- Use element animations to emphasize key content inside a slide, not every element on the slide.
+- Keep animation choices consistent within a deck.
+- Reserve `typewriter` for short plain-text copy, not complex nested markup.
+- Avoid relying on component animations as the only way content becomes understandable.
+- Remember reduced-motion users may see the final state without the animation effect.
+
 ## Build content for presenters, not just readers
 
 ### Fragments
@@ -293,6 +390,7 @@ When creating or updating a SlideWire presentation, verify that:
 - deck defaults are used for shared behavior instead of repeated slide attributes
 - text contrast, spacing, and layout are clear on both dark and light backgrounds
 - fragments improve pacing instead of hiding essential context
+- text and image components are used where their semantics or animation hooks improve authoring clarity
 - code, markdown, and diagram slides use the most appropriate component
 - route registration points to the correct presentation key
 
@@ -302,6 +400,7 @@ When creating or updating a SlideWire presentation, verify that:
 - Keep presentations in one Blade file per deck.
 - Use deck-level theme and transition defaults first.
 - Use Tailwind classes for slide composition and atmosphere.
+- Use `text` and `image` when you want semantic wrappers with built-in animation metadata.
 - Use vertical slides for drill-downs, not for unrelated content.
 - Use fragments to pace the narrative.
 - Use markdown for fast authoring, `code` for exact snippets, and `diagram` for visual structure.

--- a/resources/views/components/image.blade.php
+++ b/resources/views/components/image.blade.php
@@ -1,0 +1,9 @@
+<img
+    {{ $attributes
+        ->class(['slidewire-image'])
+        ->merge([
+            'data-slidewire-animate' => 'true',
+            'data-animation-speed' => $normalizedAnimationSpeed(),
+        ])
+        ->when($animation !== null, fn ($attributeBag) => $attributeBag->merge(['data-animation' => $animation])) }}
+/>

--- a/resources/views/components/text.blade.php
+++ b/resources/views/components/text.blade.php
@@ -1,0 +1,22 @@
+@php
+    $componentAttributes = $attributes
+        ->class([
+            'slidewire-text',
+            'slidewire-text-vertical' => $normalizedOrientation() === 'vertical',
+        ])
+        ->merge([
+            'data-slidewire-animate' => 'true',
+            'data-text-type' => $type,
+            'data-orientation' => $normalizedOrientation(),
+            'data-animation-speed' => $normalizedAnimationSpeed(),
+        ])
+        ->when($animation !== null, fn ($attributeBag) => $attributeBag->merge(['data-animation' => $animation]));
+@endphp
+
+@if($tag() === 'span')
+    <span {{ $componentAttributes }}>{{ $slot }}</span>
+@elseif($tag() === 'h2')
+    <h2 {{ $componentAttributes }}>{{ $slot }}</h2>
+@else
+    <p {{ $componentAttributes }}>{{ $slot }}</p>
+@endif

--- a/resources/views/livewire/presentation-deck.blade.php
+++ b/resources/views/livewire/presentation-deck.blade.php
@@ -148,6 +148,22 @@
         .slidewire-content .slidewire-diagram { background: transparent; opacity: 0; color: transparent; }
         .slidewire-content .slidewire-diagram[data-processed] { opacity: 1; transition: opacity .6s ease-out .1s; }
         .slidewire-content .slidewire-diagram svg { max-width: 100%; height: auto; }
+        .slidewire-text { display: block; }
+        .slidewire-image { display: block; max-width: 100%; height: auto; }
+        .slidewire-text-vertical { writing-mode: vertical-rl; text-orientation: mixed; }
+        .slidewire-typewriter { display: inline-block; white-space: nowrap; overflow: hidden; }
+        .slidewire-typewriter::after { content: ''; display: inline-block; width: 0.08em; height: 1em; margin-left: 0.12em; vertical-align: -0.12em; background: currentColor; animation: slidewire-caret 1s step-end infinite; }
+
+        @@keyframes slidewire-caret {
+            0%, 50% { opacity: 1; }
+            50.01%, 100% { opacity: 0; }
+        }
+
+        @@media (prefers-reduced-motion: reduce) {
+            .slidewire-fragment { transition: none; transform: none; }
+            .slidewire-content .slidewire-diagram[data-processed] { transition: none; }
+            .slidewire-typewriter::after { animation: none; opacity: 0; }
+        }
     </style>
 
     @script
@@ -176,12 +192,19 @@
                 isTransitioning: false,
                 transitionTimeout: null,
                 autoSlideTimeout: null,
+                reducedMotionQuery: null,
                 init() {
+                    this.reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
                     this.syncFromHash();
                     this.refreshFragments();
                     this.setupAutoSlide();
                     this.renderDiagrams();
                     this.observeDiagrams();
+
+                    this.$nextTick(() => {
+                        this.resetAnimatedNodes(this.activeSlide());
+                        this.playElementAnimations(this.activeSlide(), 'in');
+                    });
 
                     window.addEventListener('hashchange', () => this.syncFromHash());
                     document.addEventListener('fullscreenchange', () => {
@@ -240,6 +263,10 @@
                         this.playAutoAnimate(oldValue, value);
                         this.setupAutoSlide();
                         this.renderDiagrams();
+                        this.$nextTick(() => {
+                            this.resetAnimatedNodes(this.activeSlide());
+                            this.playElementAnimations(this.activeSlide(), 'in');
+                        });
                     });
 
                     this.$watch('fragment', () => {
@@ -424,6 +451,191 @@
                     }
 
                     return base;
+                },
+                prefersReducedMotion() {
+                    return this.reducedMotionQuery?.matches === true;
+                },
+                animatedNodes(slide) {
+                    if (!slide) {
+                        return [];
+                    }
+
+                    return Array.from(slide.querySelectorAll('[data-slidewire-animate]'));
+                },
+                resetAnimatedNodes(slide) {
+                    this.animatedNodes(slide).forEach((node) => {
+                        if (node._slidewireAnimation) {
+                            node._slidewireAnimation.cancel();
+                            node._slidewireAnimation = null;
+                        }
+
+                        node.classList.remove('slidewire-typewriter');
+                        node.style.opacity = '';
+                        node.style.transform = '';
+                        node.style.filter = '';
+                        node.style.clipPath = '';
+                        node.style.textShadow = '';
+                    });
+                },
+                animationDurationMultiplier(speed) {
+                    if (speed === 'fast') {
+                        return 0.8;
+                    }
+
+                    if (speed === 'default') {
+                        return 1.7;
+                    }
+
+                    return 2.2;
+                },
+                animationOptions(name, speed = 'default') {
+                    const durationMap = {
+                        fade: 1100,
+                        pop: 420,
+                        'zoom-in': 440,
+                        'zoom-out': 440,
+                        'slide-left': 620,
+                        'slide-right': 620,
+                        'slide-up': 620,
+                        'slide-down': 620,
+                        blur: 360,
+                        typewriter: 900,
+                    };
+
+                    const multiplier = this.animationDurationMultiplier(speed);
+
+                    return {
+                        duration: Math.round((durationMap[name] || 280) * multiplier),
+                        easing: name === 'typewriter' ? 'steps(18, end)' : 'cubic-bezier(0.22, 0.61, 0.36, 1)',
+                        fill: 'both',
+                    };
+                },
+                animationKeyframes(name, phase, node) {
+                    const isImage = node.tagName === 'IMG';
+
+                    if (name === 'typewriter' && isImage) {
+                        return null;
+                    }
+
+                    if (name === 'fade') {
+                        return phase === 'in'
+                            ? [{ opacity: 0 }, { opacity: 1 }]
+                            : [{ opacity: 1 }, { opacity: 0 }];
+                    }
+
+                    if (name === 'pop') {
+                        return phase === 'in'
+                            ? [{ opacity: 0, transform: 'scale(0.82)' }, { opacity: 1, transform: 'scale(1)' }]
+                            : [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.92)' }];
+                    }
+
+                    if (name === 'zoom-in') {
+                        return phase === 'in'
+                            ? [{ opacity: 0, transform: 'scale(1.16)' }, { opacity: 1, transform: 'scale(1)' }]
+                            : [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(1.08)' }];
+                    }
+
+                    if (name === 'zoom-out') {
+                        return phase === 'in'
+                            ? [{ opacity: 0, transform: 'scale(0.84)' }, { opacity: 1, transform: 'scale(1)' }]
+                            : [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.84)' }];
+                    }
+
+                    if (name === 'slide-left') {
+                        return phase === 'in'
+                            ? [{ opacity: 0, transform: 'translateX(2rem)' }, { opacity: 1, transform: 'translateX(0)' }]
+                            : [{ opacity: 1, transform: 'translateX(0)' }, { opacity: 0, transform: 'translateX(-2rem)' }];
+                    }
+
+                    if (name === 'slide-right') {
+                        return phase === 'in'
+                            ? [{ opacity: 0, transform: 'translateX(-2rem)' }, { opacity: 1, transform: 'translateX(0)' }]
+                            : [{ opacity: 1, transform: 'translateX(0)' }, { opacity: 0, transform: 'translateX(2rem)' }];
+                    }
+
+                    if (name === 'slide-up') {
+                        return phase === 'in'
+                            ? [{ opacity: 0, transform: 'translateY(2rem)' }, { opacity: 1, transform: 'translateY(0)' }]
+                            : [{ opacity: 1, transform: 'translateY(0)' }, { opacity: 0, transform: 'translateY(-2rem)' }];
+                    }
+
+                    if (name === 'slide-down') {
+                        return phase === 'in'
+                            ? [{ opacity: 0, transform: 'translateY(-2rem)' }, { opacity: 1, transform: 'translateY(0)' }]
+                            : [{ opacity: 1, transform: 'translateY(0)' }, { opacity: 0, transform: 'translateY(2rem)' }];
+                    }
+
+                    if (name === 'blur') {
+                        return phase === 'in'
+                            ? [{ opacity: 0, filter: 'blur(18px)' }, { opacity: 1, filter: 'blur(0)' }]
+                            : [{ opacity: 1, filter: 'blur(0)' }, { opacity: 0, filter: 'blur(18px)' }];
+                    }
+
+                    if (name === 'typewriter') {
+                        return phase === 'in'
+                            ? [
+                                { opacity: 1, clipPath: 'inset(0 100% 0 0)' },
+                                { opacity: 1, clipPath: 'inset(0 0 0 0)' },
+                            ]
+                            : [{ opacity: 1 }, { opacity: 0 }];
+                    }
+
+                    return null;
+                },
+                playElementAnimations(slide, phase) {
+                    const nodes = this.animatedNodes(slide);
+
+                    if (nodes.length === 0) {
+                        return;
+                    }
+
+                    if (this.prefersReducedMotion()) {
+                        this.resetAnimatedNodes(slide);
+
+                        return;
+                    }
+
+                    nodes.forEach((node, nodeIndex) => {
+                        const animationName = phase === 'in' ? (node.dataset.animation || '') : '';
+                        const keyframes = this.animationKeyframes(animationName, phase, node);
+
+                        if (!animationName || keyframes === null) {
+                            return;
+                        }
+
+                        if (animationName === 'typewriter' && phase === 'in') {
+                            node.classList.add('slidewire-typewriter');
+                        }
+
+                        const animationSpeed = node.dataset.animationSpeed || 'default';
+                        const options = this.animationOptions(animationName, animationSpeed);
+                        const animation = node.animate(keyframes, {
+                            ...options,
+                            delay: phase === 'in' ? nodeIndex * 50 : 0,
+                        });
+
+                        node._slidewireAnimation = animation;
+
+                        animation.finished
+                            .catch(() => {})
+                            .finally(() => {
+                                if (node._slidewireAnimation === animation) {
+                                    node._slidewireAnimation = null;
+                                }
+
+                                if (phase === 'out' || animationName !== 'typewriter') {
+                                    node.classList.remove('slidewire-typewriter');
+                                }
+
+                                if (phase === 'out') {
+                                    node.style.opacity = '';
+                                    node.style.transform = '';
+                                    node.style.filter = '';
+                                    node.style.clipPath = '';
+                                    node.style.textShadow = '';
+                                }
+                            });
+                    });
                 },
                 playTransition(oldIndex, newIndex) {
                     if (oldIndex === undefined || oldIndex === null || oldIndex === newIndex) {

--- a/src/View/Components/Image.php
+++ b/src/View/Components/Image.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\SlideWire\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+use WendellAdriel\SlideWire\Enums\SlideTransitionSpeed;
+
+class Image extends Component
+{
+    public function __construct(
+        public ?string $animation = null,
+        public string $animationSpeed = SlideTransitionSpeed::Default->value,
+    ) {
+        $this->animationSpeed = $this->normalizeAnimationSpeed($this->animationSpeed);
+    }
+
+    public function render(): View|Closure|string
+    {
+        return view('slidewire::components.image');
+    }
+
+    public function normalizedAnimationSpeed(): string
+    {
+        return $this->animationSpeed;
+    }
+
+    protected function normalizeAnimationSpeed(string $animationSpeed): string
+    {
+        return in_array($animationSpeed, SlideTransitionSpeed::values(), true)
+            ? $animationSpeed
+            : SlideTransitionSpeed::Default->value;
+    }
+}

--- a/src/View/Components/Text.php
+++ b/src/View/Components/Text.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\SlideWire\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+use WendellAdriel\SlideWire\Enums\SlideTransitionSpeed;
+
+class Text extends Component
+{
+    public function __construct(
+        public string $type = 'paragraph',
+        public string $orientation = 'horizontal',
+        public ?string $animation = null,
+        public string $animationSpeed = SlideTransitionSpeed::Default->value,
+    ) {
+        $this->type = $this->normalizeType($this->type);
+        $this->orientation = $this->normalizeOrientation($this->orientation);
+        $this->animationSpeed = $this->normalizeAnimationSpeed($this->animationSpeed);
+    }
+
+    public function render(): View|Closure|string
+    {
+        return view('slidewire::components.text');
+    }
+
+    public function tag(): string
+    {
+        return match ($this->type) {
+            'inline' => 'span',
+            'heading' => 'h2',
+            default => 'p',
+        };
+    }
+
+    public function normalizedOrientation(): string
+    {
+        return $this->orientation;
+    }
+
+    public function normalizedAnimationSpeed(): string
+    {
+        return $this->animationSpeed;
+    }
+
+    protected function normalizeType(string $type): string
+    {
+        return in_array($type, ['paragraph', 'inline', 'heading'], true)
+            ? $type
+            : 'paragraph';
+    }
+
+    protected function normalizeOrientation(string $orientation): string
+    {
+        return in_array($orientation, ['horizontal', 'vertical'], true)
+            ? $orientation
+            : 'horizontal';
+    }
+
+    protected function normalizeAnimationSpeed(string $animationSpeed): string
+    {
+        return in_array($animationSpeed, SlideTransitionSpeed::values(), true)
+            ? $animationSpeed
+            : SlideTransitionSpeed::Default->value;
+    }
+}

--- a/tests/Feature/ImageComponentTest.php
+++ b/tests/Feature/ImageComponentTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+it('renders an image tag and forwards native attributes', function (): void {
+    $html = Blade::render(<<<'BLADE'
+<x-slidewire::image
+    src="/images/hero.png"
+    alt="Hero image"
+    class="w-72 rounded-2xl"
+    loading="lazy"
+    width="320"
+/>
+BLADE);
+
+    expect($html)
+        ->toContain('<img')
+        ->toContain('src="/images/hero.png"')
+        ->toContain('alt="Hero image"')
+        ->toContain('class="slidewire-image w-72 rounded-2xl"')
+        ->toContain('loading="lazy"')
+        ->toContain('width="320"')
+        ->toContain('data-slidewire-animate="true"')
+        ->toContain('data-animation-speed="default"');
+});
+
+it('emits animation data attributes when provided', function (): void {
+    $html = Blade::render(<<<'BLADE'
+<x-slidewire::image src="/images/product.png" alt="Product shot" animation="pop" animation-speed="default" />
+BLADE);
+
+    expect($html)
+        ->toContain('data-animation="pop"')
+        ->toContain('data-animation-speed="default"');
+});
+
+it('omits optional animation data when not provided', function (): void {
+    $html = Blade::render('<x-slidewire::image src="/images/product.png" alt="Product shot" />');
+
+    expect($html)
+        ->not->toContain('data-animation=');
+});
+
+it('treats unsupported animation names as plain output rather than erroring', function (): void {
+    $html = Blade::render('<x-slidewire::image src="/images/product.png" alt="Product shot" animation="typewriter" />');
+
+    expect($html)
+        ->toContain('data-animation="typewriter"');
+});
+
+it('falls back safely for invalid animation speed', function (): void {
+    $html = Blade::render('<x-slidewire::image src="/images/product.png" alt="Product shot" animation-speed="warp" />');
+
+    expect($html)->toContain('data-animation-speed="default"');
+});

--- a/tests/Feature/PresentationDeckComponentTest.php
+++ b/tests/Feature/PresentationDeckComponentTest.php
@@ -170,3 +170,42 @@ it('includes renderDiagrams method in deck JavaScript', function (): void {
 
     expect($content)->toContain('renderDiagrams');
 });
+
+it('renders text and image components inside a real deck', function (): void {
+    Route::slidewire('/slides/component-animations', 'component-animations');
+
+    test()->get('/slides/component-animations')
+        ->assertSuccessful()
+        ->assertSee('Launch Day')
+        ->assertSee('Product reveal')
+        ->assertSee('Product shot');
+});
+
+it('preserves component animation metadata and vertical text hooks in deck output', function (): void {
+    Route::slidewire('/slides/component-animations', 'component-animations');
+
+    $content = test()->get('/slides/component-animations')->getContent();
+
+    expect($content)
+        ->toContain('data-slidewire-animate="true"')
+        ->toContain('data-animation="slide-up"')
+        ->toContain('data-animation="pop"')
+        ->toContain('data-animation-speed="default"')
+        ->toContain('data-animation-speed="fast"')
+        ->toContain('slidewire-text-vertical')
+        ->toContain('data-orientation="vertical"');
+});
+
+it('includes element animation helper logic in deck JavaScript', function (): void {
+    Route::slidewire('/slides/component-animations', 'component-animations');
+
+    $content = test()->get('/slides/component-animations')->getContent();
+
+    expect($content)
+        ->toContain('animatedNodes(slide)')
+        ->toContain('playElementAnimations(slide, phase)')
+        ->toContain('animationKeyframes(name, phase, node)')
+        ->toContain('animationDurationMultiplier(speed)')
+        ->toContain('resetAnimatedNodes(slide)')
+        ->toContain('prefers-reduced-motion: reduce');
+});

--- a/tests/Feature/PresentationDeckExpandedTest.php
+++ b/tests/Feature/PresentationDeckExpandedTest.php
@@ -122,3 +122,15 @@ it('preserves vertical scroll gestures before triggering vertical navigation', f
         ->toContain('shouldPreserveVerticalScroll')
         ->toContain('canScrollActiveSlide');
 });
+
+it('includes package css hooks for text, image, and typewriter animations', function (): void {
+    Route::slidewire('/slides/component-animations', 'component-animations');
+
+    $content = test()->get('/slides/component-animations')->getContent();
+
+    expect($content)
+        ->toContain('.slidewire-text')
+        ->toContain('.slidewire-image')
+        ->toContain('.slidewire-text-vertical')
+        ->toContain('.slidewire-typewriter');
+});

--- a/tests/Feature/TextComponentTest.php
+++ b/tests/Feature/TextComponentTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+it('renders a paragraph tag by default', function (): void {
+    $html = Blade::render('<x-slidewire::text>Hello world</x-slidewire::text>');
+
+    expect($html)
+        ->toContain('<p')
+        ->toContain('Hello world')
+        ->toContain('data-text-type="paragraph"')
+        ->toContain('data-orientation="horizontal"')
+        ->toContain('data-animation-speed="default"');
+});
+
+it('renders span for inline type', function (): void {
+    $html = Blade::render('<x-slidewire::text type="inline">Inline</x-slidewire::text>');
+
+    expect($html)->toContain('<span');
+});
+
+it('renders h2 for heading type', function (): void {
+    $html = Blade::render('<x-slidewire::text type="heading">Heading</x-slidewire::text>');
+
+    expect($html)->toContain('<h2');
+});
+
+it('falls back safely for invalid type', function (): void {
+    $html = Blade::render('<x-slidewire::text type="unknown">Fallback</x-slidewire::text>');
+
+    expect($html)
+        ->toContain('<p')
+        ->toContain('data-text-type="paragraph"');
+});
+
+it('marks vertical orientation correctly', function (): void {
+    $html = Blade::render('<x-slidewire::text orientation="vertical">Vertical</x-slidewire::text>');
+
+    expect($html)
+        ->toContain('slidewire-text-vertical')
+        ->toContain('data-orientation="vertical"');
+});
+
+it('falls back safely for invalid orientation', function (): void {
+    $html = Blade::render('<x-slidewire::text orientation="diagonal">Fallback</x-slidewire::text>');
+
+    expect($html)->toContain('data-orientation="horizontal"');
+});
+
+it('forwards custom classes and animation data attributes', function (): void {
+    $html = Blade::render(<<<'BLADE'
+<x-slidewire::text class="text-5xl font-semibold" animation="slide-up" animation-speed="fast">
+    Launch Day
+</x-slidewire::text>
+BLADE);
+
+    expect($html)
+        ->toContain('text-5xl')
+        ->toContain('font-semibold')
+        ->toContain('data-animation="slide-up"')
+        ->toContain('data-animation-speed="fast"');
+});
+
+it('falls back safely for invalid animation speed', function (): void {
+    $html = Blade::render('<x-slidewire::text animation-speed="warp">Fallback</x-slidewire::text>');
+
+    expect($html)->toContain('data-animation-speed="default"');
+});
+
+it('preserves nested inline html inside the slot', function (): void {
+    $html = Blade::render(<<<'BLADE'
+<x-slidewire::text>
+    Launch <strong>Day</strong>
+</x-slidewire::text>
+BLADE);
+
+    expect($html)->toContain('<strong>Day</strong>');
+});

--- a/tests/fixtures/views/pages/slides/component-animations.blade.php
+++ b/tests/fixtures/views/pages/slides/component-animations.blade.php
@@ -1,0 +1,41 @@
+<?php
+
+use Livewire\Component;
+
+new class() extends Component
+{
+    //
+}; ?>
+
+<x-slidewire::deck>
+    <x-slidewire::slide class="bg-slate-950 text-white">
+        <x-slidewire::text
+            type="heading"
+            orientation="vertical"
+            animation="slide-up"
+            animation-speed="slow"
+            class="text-5xl font-semibold"
+        >
+            Launch Day
+        </x-slidewire::text>
+
+        <x-slidewire::text animation="typewriter" animation-speed="slow" class="mt-8 text-2xl">
+            Components that animate with the deck runtime.
+        </x-slidewire::text>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide class="bg-white text-slate-900">
+        <x-slidewire::image
+            src="/images/product-shot.png"
+            alt="Product shot"
+            class="w-72 rounded-2xl shadow-2xl"
+            loading="lazy"
+            animation="pop"
+            animation-speed="default"
+        />
+
+        <x-slidewire::text type="inline" animation="blur" animation-speed="fast" class="mt-6 text-xl">
+            Product reveal
+        </x-slidewire::text>
+    </x-slidewire::slide>
+</x-slidewire::deck>


### PR DESCRIPTION
Add first-class text and image components so devs can attach semantic markup and element-level animations without repeating raw HTML and data attributes.

### Usage

```blade
<x-slidewire::text type="heading" animation="slide-up">
    Launch Day
</x-slidewire::text>

<x-slidewire::image src="/images/product-shot.png" alt="Product shot" animation="pop" />
```

### Approach

- add native text and image wrappers with safe defaults for orientation and animation speed
- extend the deck runtime with reusable element animation handling and reduced-motion support