### PR TITLE
feat: add fragment-aware navigation and mobile scroll improvements

### DIFF
--- a/resources/views/livewire/presentation-deck.blade.php
+++ b/resources/views/livewire/presentation-deck.blade.php
@@ -89,7 +89,7 @@
 
         @if($showControls)
             <nav class="slidewire-controls" aria-label="Slide controls">
-                <button type="button" x-on:click.stop="navigateLeft()" aria-label="Previous slide" class="slidewire-control-arrow slidewire-control-left" :disabled="!canGoLeft()">
+                <button type="button" x-on:click.stop="previous()" aria-label="Previous slide" class="slidewire-control-arrow slidewire-control-left" :disabled="!canGoLeft()">
                     <svg viewBox="0 0 20 20" fill="currentColor" width="18" height="18"><path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
                 </button>
                 @if($hasVerticalSlides)
@@ -100,7 +100,7 @@
                         <svg viewBox="0 0 20 20" fill="currentColor" width="18" height="18"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
                     </button>
                 @endif
-                <button type="button" x-on:click.stop="navigateRight()" aria-label="Next slide" class="slidewire-control-arrow slidewire-control-right" :disabled="!canGoRight()">
+                <button type="button" x-on:click.stop="next()" aria-label="Next slide" class="slidewire-control-arrow slidewire-control-right" :disabled="!canGoRight()">
                     <svg viewBox="0 0 20 20" fill="currentColor" width="18" height="18"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/></svg>
                 </button>
                 @if($showFullscreenButton)
@@ -206,7 +206,7 @@
                         this.playElementAnimations(this.activeSlide(), 'in');
                     });
 
-                    window.addEventListener('hashchange', () => this.syncFromHash());
+                    window.addEventListener('popstate', () => this.syncFromHash());
                     document.addEventListener('fullscreenchange', () => {
                         this.isFullscreen = document.fullscreenElement !== null;
                     });
@@ -258,6 +258,7 @@
 
                     this.$watch('index', (value, oldValue) => {
                         this.updateHash();
+                        this.scrollActiveSlideIntoView(value);
                         this.playTransition(oldValue, value);
                         this.refreshFragments();
                         this.playAutoAnimate(oldValue, value);
@@ -270,6 +271,7 @@
                     });
 
                     this.$watch('fragment', () => {
+                        this.updateHash();
                         this.refreshFragments();
                         this.setupAutoSlide();
                     });
@@ -355,13 +357,13 @@
                     event.preventDefault();
 
                     if (direction === 'right') {
-                        this.navigateRight();
+                        this.next();
 
                         return;
                     }
 
                     if (direction === 'left') {
-                        this.navigateLeft();
+                        this.previous();
 
                         return;
                     }
@@ -374,14 +376,25 @@
 
                     this.navigateUp();
                 },
-                updateHash() {
+                buildHash() {
                     const { h, v } = this.currentCoords();
+                    const f = this.fragment;
+                    let hash;
 
                     if (v > 0) {
-                        window.location.hash = `#/slide/${h + 1}/${v + 1}`;
+                        hash = `#/slide/${h + 1}/${v + 1}`;
                     } else {
-                        window.location.hash = `#/slide/${h + 1}`;
+                        hash = `#/slide/${h + 1}`;
                     }
+
+                    if (f > -1) {
+                        hash += `/f/${f}`;
+                    }
+
+                    return hash;
+                },
+                updateHash() {
+                    history.pushState(null, '', this.buildHash());
                 },
                 frameClass(slideIndex) {
                     if (slideIndex === this.index) {
@@ -400,7 +413,13 @@
 
                     return classes || '';
                 },
+                parseFragmentFromHash() {
+                    const fMatch = window.location.hash.match(/\/f\/(\d+)/);
+
+                    return fMatch ? Number(fMatch[1]) : -1;
+                },
                 syncFromHash() {
+                    const fragment = this.parseFragmentFromHash();
                     const match2d = window.location.hash.match(/#\/slide\/(\d+)\/(\d+)/);
 
                     if (match2d) {
@@ -410,7 +429,7 @@
 
                         if (target >= 0) {
                             this.captureAutoAnimateSnapshot(target);
-                            this.$wire.goToSlide(target);
+                            this.$wire.goToSlide(target, fragment);
                         }
 
                         return;
@@ -424,7 +443,7 @@
 
                         if (target >= 0) {
                             this.captureAutoAnimateSnapshot(target);
-                            this.$wire.goToSlide(target);
+                            this.$wire.goToSlide(target, fragment);
                         }
                     }
                 },
@@ -775,6 +794,13 @@
                         scrollHeight: container.scrollHeight,
                     };
                 },
+                scrollActiveSlideIntoView(slideIndex) {
+                    const slide = this.$refs[`slide${slideIndex}`];
+
+                    if (slide) {
+                        slide.scrollTo({ top: 0, behavior: 'smooth' });
+                    }
+                },
                 canScrollContainer(direction, state) {
                     if (!state || !state.container) {
                         return false;
@@ -1077,13 +1103,25 @@
                         }
 
                         const nodes = slide.querySelectorAll('[data-fragment]');
+                        let lastVisible = null;
 
                         nodes.forEach((node, currentIndex) => {
                             const explicit = node.getAttribute('data-fragment-index');
                             const fragmentIndex = explicit === null ? currentIndex : Number(explicit);
+                            const isVisible = fragmentIndex <= this.fragment;
 
-                            node.classList.toggle('slidewire-fragment-visible', fragmentIndex <= this.fragment);
+                            node.classList.toggle('slidewire-fragment-visible', isVisible);
+
+                            if (isVisible) {
+                                lastVisible = node;
+                            }
                         });
+
+                        if (lastVisible) {
+                            lastVisible.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                        } else if (nodes.length > 0) {
+                            slide.scrollTo({ top: 0, behavior: 'smooth' });
+                        }
                     });
                 }
             }

--- a/resources/views/livewire/presentation-deck.blade.php
+++ b/resources/views/livewire/presentation-deck.blade.php
@@ -186,6 +186,7 @@
                 touchStartX: null,
                 touchStartY: null,
                 touchScrollState: null,
+                hashUpdateQueued: false,
                 isFullscreen: false,
                 autoAnimateSnapshot: null,
                 leavingIndex: null,
@@ -257,7 +258,7 @@
                     }, { passive: true });
 
                     this.$watch('index', (value, oldValue) => {
-                        this.updateHash();
+                        this.queueHashUpdate();
                         this.scrollActiveSlideIntoView(value);
                         this.playTransition(oldValue, value);
                         this.refreshFragments();
@@ -271,7 +272,7 @@
                     });
 
                     this.$watch('fragment', () => {
-                        this.updateHash();
+                        this.queueHashUpdate();
                         this.refreshFragments();
                         this.setupAutoSlide();
                     });
@@ -289,11 +290,19 @@
                     return -1;
                 },
                 canGoLeft() {
+                    if (this.fragment > -1) {
+                        return true;
+                    }
+
                     const { h } = this.currentCoords();
 
                     return h > 0;
                 },
                 canGoRight() {
+                    if (this.fragment < this.fragmentCountForSlide() - 1) {
+                        return true;
+                    }
+
                     const { h } = this.currentCoords();
 
                     return h < this.gridShape.length - 1;
@@ -394,7 +403,25 @@
                     return hash;
                 },
                 updateHash() {
-                    history.pushState(null, '', this.buildHash());
+                    const hash = this.buildHash();
+
+                    if (window.location.hash === hash) {
+                        return;
+                    }
+
+                    history.pushState(null, '', hash);
+                },
+                queueHashUpdate() {
+                    if (this.hashUpdateQueued) {
+                        return;
+                    }
+
+                    this.hashUpdateQueued = true;
+
+                    queueMicrotask(() => {
+                        this.hashUpdateQueued = false;
+                        this.updateHash();
+                    });
                 },
                 frameClass(slideIndex) {
                     if (slideIndex === this.index) {
@@ -779,6 +806,15 @@
                 },
                 activeSlide() {
                     return this.$refs[`slide${this.index}`] || null;
+                },
+                fragmentCountForSlide(slideIndex = this.index) {
+                    const slide = this.$refs[`slide${slideIndex}`];
+
+                    if (!slide) {
+                        return 0;
+                    }
+
+                    return slide.querySelectorAll('[data-fragment]').length;
                 },
                 captureScrollState(target) {
                     const container = this.activeSlide();

--- a/src/Livewire/PresentationDeck.php
+++ b/src/Livewire/PresentationDeck.php
@@ -76,14 +76,20 @@ class PresentationDeck extends Component
             return;
         }
 
-        $this->activeIndex = max($this->activeIndex - 1, 0);
-        $this->activeFragment = -1;
+        $previousIndex = max($this->activeIndex - 1, 0);
+
+        if ($previousIndex === $this->activeIndex) {
+            return;
+        }
+
+        $this->activeIndex = $previousIndex;
+        $this->activeFragment = max($this->slides[$this->activeIndex]->fragments - 1, -1);
     }
 
-    public function goToSlide(int $index): void
+    public function goToSlide(int $index, int $fragment = -1): void
     {
         $this->activeIndex = $this->normalizeIndex($index);
-        $this->activeFragment = -1;
+        $this->activeFragment = $fragment;
     }
 
     public function navigateDown(): void

--- a/tests/Browser/FragmentNavigationBrowserTest.php
+++ b/tests/Browser/FragmentNavigationBrowserTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('keeps fragment controls enabled while fragment steps remain', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/fragment-controls', 'fragment-controls');
+
+    $page = visit('/slides/fragment-controls');
+
+    $page->waitForText('First Edge')
+        ->assertSee('First Edge')
+        ->assertNoJavaScriptErrors();
+
+    $page->script("document.querySelector('.slidewire-control-right').click()");
+    $page->wait(0.5);
+
+    expect($page->script("document.querySelector('.slidewire-control-left').disabled"))
+        ->toBeFalse();
+
+    for ($i = 0; $i < 3; ++$i) {
+        $page->script("document.querySelector('.slidewire-stage').click()");
+        $page->wait(0.5);
+    }
+
+    $page->assertSee('Last Edge')
+        ->assertNoJavaScriptErrors();
+
+    expect($page->script("document.querySelector('.slidewire-control-right').disabled"))
+        ->toBeFalse();
+})->group('browser');
+
+it('persists fragment position in the hash and restores it with browser navigation', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/fragments', 'fragments');
+
+    $page = visit('/slides/fragments');
+
+    $page->waitForText('Fragment Slide')
+        ->assertSee('Fragment Slide')
+        ->assertNoJavaScriptErrors();
+
+    for ($i = 0; $i < 2; ++$i) {
+        $page->script("document.querySelector('.slidewire-stage').click()");
+        $page->wait(0.5);
+    }
+
+    expect($page->script('window.location.hash'))->toBe('#/slide/1/f/1')
+        ->and($page->script("document.querySelectorAll('.slidewire-frame.is-active [data-fragment].slidewire-fragment-visible').length"))
+        ->toBe(2);
+
+    $page->script('window.history.back()');
+    $page->wait(0.5);
+
+    expect($page->script('window.location.hash'))->toBe('#/slide/1/f/0')
+        ->and($page->script("document.querySelectorAll('.slidewire-frame.is-active [data-fragment].slidewire-fragment-visible').length"))
+        ->toBe(1);
+
+    $page->script('window.history.forward()');
+    $page->wait(0.5);
+
+    expect($page->script('window.location.hash'))->toBe('#/slide/1/f/1')
+        ->and($page->script("document.querySelectorAll('.slidewire-frame.is-active [data-fragment].slidewire-fragment-visible').length"))
+        ->toBe(2);
+
+    $page->assertNoJavaScriptErrors();
+})->group('browser');
+
+it('returns to the previous slide fragment state in one back navigation step', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/fragments', 'fragments');
+
+    $page = visit('/slides/fragments');
+
+    $page->waitForText('Fragment Slide')
+        ->assertSee('Fragment Slide')
+        ->assertNoJavaScriptErrors();
+
+    for ($i = 0; $i < 4; ++$i) {
+        $page->script("document.querySelector('.slidewire-stage').click()");
+        $page->wait(0.5);
+    }
+
+    expect($page->script('window.location.hash'))->toBe('#/slide/2');
+
+    $page->script('window.history.back()');
+    $page->wait(0.5);
+
+    expect($page->script('window.location.hash'))->toBe('#/slide/1/f/2')
+        ->and($page->script("document.querySelector('.slidewire-frame.is-active h1').textContent.trim()"))
+        ->toBe('Fragment Slide')
+        ->and($page->script("document.querySelectorAll('.slidewire-frame.is-active [data-fragment].slidewire-fragment-visible').length"))
+        ->toBe(3);
+
+    $page->assertNoJavaScriptErrors();
+})->group('browser');

--- a/tests/Browser/ScrollResetBrowserTest.php
+++ b/tests/Browser/ScrollResetBrowserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('scrolls new slide to top when navigating on mobile viewport', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/scroll-reset', 'scroll-reset');
+
+    $page = visit('/slides/scroll-reset');
+
+    $page->resize(375, 667)
+        ->assertSee('AI Ready')
+        ->assertNoJavaScriptErrors();
+
+    // Scroll the first slide down.
+    $page->script("document.querySelector('.slidewire-frame.is-active').scrollTo(0, 9999)");
+    $page->wait(0.3);
+
+    $scrollBefore = $page->script("document.querySelector('.slidewire-frame.is-active').scrollTop");
+    expect($scrollBefore)->toBeGreaterThan(0);
+
+    // Click the stage to advance through all fragments, then to the next slide.
+    for ($i = 0; $i < 6; ++$i) {
+        $page->script("document.querySelector('.slidewire-stage').click()");
+        $page->wait(0.5);
+    }
+
+    // The new slide should be scrolled to the top.
+    $scrollAfter = $page->script("document.querySelector('.slidewire-frame.is-active').scrollTop");
+    expect($scrollAfter)->toBe(0);
+
+    $page->assertSee('Getting Started')
+        ->assertNoJavaScriptErrors();
+})->group('browser');
+
+it('scrolls fragment into view on mobile viewport', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/scroll-reset', 'scroll-reset');
+
+    $page = visit('/slides/scroll-reset');
+
+    $page->resize(375, 667)
+        ->assertSee('AI Ready')
+        ->assertNoJavaScriptErrors();
+
+    // Advance through all fragments by clicking the stage.
+    for ($i = 0; $i < 5; ++$i) {
+        $page->script("document.querySelector('.slidewire-stage').click()");
+        $page->wait(0.5);
+    }
+
+    // The last fragment should be visible.
+    $page->assertSee('Quality Enforced')
+        ->assertNoJavaScriptErrors();
+})->group('browser');

--- a/tests/fixtures/views/pages/slides/fragment-controls.blade.php
+++ b/tests/fixtures/views/pages/slides/fragment-controls.blade.php
@@ -1,0 +1,38 @@
+<?php
+
+use Livewire\Component;
+
+new class() extends Component
+{
+    //
+}; ?>
+
+<x-slidewire::deck>
+    <x-slidewire::slide class="bg-slate-900 text-white">
+        <h1>First Edge</h1>
+
+        <x-slidewire::fragment :index="0">
+            <p>First fragment</p>
+        </x-slidewire::fragment>
+
+        <x-slidewire::fragment :index="1">
+            <p>Second fragment</p>
+        </x-slidewire::fragment>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide class="bg-slate-800 text-white">
+        <h1>Middle Slide</h1>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide class="bg-slate-700 text-white">
+        <h1>Last Edge</h1>
+
+        <x-slidewire::fragment :index="0">
+            <p>Last fragment</p>
+        </x-slidewire::fragment>
+
+        <x-slidewire::fragment :index="1">
+            <p>Final fragment</p>
+        </x-slidewire::fragment>
+    </x-slidewire::slide>
+</x-slidewire::deck>

--- a/tests/fixtures/views/pages/slides/scroll-reset.blade.php
+++ b/tests/fixtures/views/pages/slides/scroll-reset.blade.php
@@ -1,0 +1,82 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component {
+    //
+}; ?>
+
+<x-slidewire::deck>
+    <x-slidewire::slide>
+        <h1 style="font-size: 2rem; font-weight: bold; color: #fff; margin: 0 0 0.5rem;">AI Ready</h1>
+        <p style="color: #cbd5e1; font-size: 1.1rem; margin: 0 0 2rem;">SlideWire ships with a Boost AI skill for beautiful deck creation.</p>
+
+        <x-slidewire::fragment>
+            <div style="background: #7c3aed; color: #fff; border-radius: 1rem; padding: 2rem; margin-bottom: 1.5rem;">
+                <h3 style="font-size: 1.1rem; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.5rem;">Workflow Aware</h3>
+                <p style="margin: 0;">Steers agents toward make:slidewire, single-file decks, and route macro registration.</p>
+            </div>
+        </x-slidewire::fragment>
+
+        <x-slidewire::fragment>
+            <div style="background: #2563eb; color: #fff; border-radius: 1rem; padding: 2rem; margin-bottom: 1.5rem;">
+                <h3 style="font-size: 1.1rem; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.5rem;">Component Smart</h3>
+                <p style="margin: 0;">Helps agents reach for slides, fragments, markdown, code, and diagrams at the right time.</p>
+            </div>
+        </x-slidewire::fragment>
+
+        <x-slidewire::fragment>
+            <div style="background: #059669; color: #fff; border-radius: 1rem; padding: 2rem; margin-bottom: 1.5rem;">
+                <h3 style="font-size: 1.1rem; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.5rem;">Design Guided</h3>
+                <p style="margin: 0;">Encodes layout patterns, color rules, and typography so AI output looks polished.</p>
+            </div>
+        </x-slidewire::fragment>
+
+        <x-slidewire::fragment>
+            <div style="background: #d97706; color: #fff; border-radius: 1rem; padding: 2rem; margin-bottom: 1.5rem;">
+                <h3 style="font-size: 1.1rem; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.5rem;">Context Loaded</h3>
+                <p style="margin: 0;">Provides full package context so the agent never guesses at API surfaces.</p>
+            </div>
+        </x-slidewire::fragment>
+
+        <x-slidewire::fragment>
+            <div style="background: #dc2626; color: #fff; border-radius: 1rem; padding: 2rem;">
+                <h3 style="font-size: 1.1rem; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.5rem;">Quality Enforced</h3>
+                <p style="margin: 0;">Runs lint, type-check, and test gates automatically.</p>
+            </div>
+        </x-slidewire::fragment>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide>
+        <h1 style="font-size: 2rem; font-weight: bold; color: #fff; margin: 0 0 0.5rem;">Getting Started</h1>
+        <p style="color: #cbd5e1; font-size: 1.1rem; margin: 0 0 2rem;">Install and create your first presentation.</p>
+
+        <x-slidewire::fragment>
+            <div style="background: #be185d; color: #fff; border-radius: 1rem; padding: 2rem; margin-bottom: 1.5rem;">
+                <h3 style="font-size: 1.1rem; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.5rem;">Step 1: Install</h3>
+                <p style="margin: 0;">Run composer require slidewire/slidewire and publish the config.</p>
+            </div>
+        </x-slidewire::fragment>
+
+        <x-slidewire::fragment>
+            <div style="background: #0d9488; color: #fff; border-radius: 1rem; padding: 2rem; margin-bottom: 1.5rem;">
+                <h3 style="font-size: 1.1rem; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.5rem;">Step 2: Scaffold</h3>
+                <p style="margin: 0;">Use php artisan make:slidewire to generate your deck boilerplate.</p>
+            </div>
+        </x-slidewire::fragment>
+
+        <x-slidewire::fragment>
+            <div style="background: #ca8a04; color: #fff; border-radius: 1rem; padding: 2rem;">
+                <h3 style="font-size: 1.1rem; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 0.5rem;">Step 3: Present</h3>
+                <p style="margin: 0;">Open in any browser — keyboard, touch, and fullscreen all work out of the box.</p>
+            </div>
+        </x-slidewire::fragment>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide>
+        <div style="text-align: center;">
+            <h1 style="font-size: 2rem; font-weight: bold; color: #fff;">Short Slide</h1>
+            <p style="color: #94a3b8; font-size: 1.25rem;">This one fits without scrolling.</p>
+        </div>
+    </x-slidewire::slide>
+</x-slidewire::deck>


### PR DESCRIPTION
Hey! 

Great job on the package! I've added some functionality on fragments so they react to keyboard and If I refresh the page they are not lost (url changes). A lot of my users are mobile users so I also improved scroll into view functionality, when next fragments are rendered below. Let me know what you think! (Feel free to push code directly if you have some preferences on how things are done). 

Thanks! 

https://github.com/user-attachments/assets/b20413e5-0d9e-41fb-b59a-86bceb3bb439

- Arrow keys (left/right) and control buttons now step through fragments before advancing to the next slide
- Going back to a previous slide restores all its fragments as visible, allowing reverse stepping through them
- Fragment state is persisted in the URL hash (#/slide/H/f/F) using history.pushState, enabling browser back/forward to restore fragment position without page flicker
- New slides scroll to top on navigation
- Newly revealed fragments smooth-scroll into view on mobile when they appear outside the viewport
- Hiding all fragments (stepping back) scrolls the slide back to top
- goToSlide() now accepts an optional fragment parameter for hash-based restoration