### PR TITLE
Support media split layout

### DIFF
--- a/resources/boost/skills/slidewire-development/SKILL.md
+++ b/resources/boost/skills/slidewire-development/SKILL.md
@@ -84,6 +84,7 @@ Without those `@source` entries, package components may render with missing styl
 - `<x-slidewire::panel>`: reusable modern surface for grouped content, supporting variants like `default`, `elevated`, `outlined`, and `glass`.
 - `<x-slidewire::title-slide>`: opinionated opening slide for titles, subtitles, overlines, and presenter metadata.
 - `<x-slidewire::two-column-slide>`: responsive split layout for explanation-plus-supporting-content slides.
+- `<x-slidewire::media-split-slide>`: media-first split layout with left/right positioning, ratio controls, and optional framed or panel-style media treatment.
 - `<x-slidewire::timeline-slide>` and `<x-slidewire::timeline-item>`: structured milestone and roadmap layouts.
 - `<x-slidewire::steps-slide>` and `<x-slidewire::step-item>`: process and rollout layouts with optional auto-numbering.
 - `<x-slidewire::agenda-slide>` and `<x-slidewire::agenda-item>`: section overview and agenda layouts.
@@ -98,6 +99,7 @@ Without those `@source` entries, package components may render with missing styl
 - Use `panel` when content needs a polished surface without rebuilding the same rounded, theme-aware wrapper.
 - Use `title-slide` for opening slides, chapter intros, and title cards.
 - Use `two-column-slide` for explanatory layouts that pair copy with supporting visuals or code.
+- Use `media-split-slide` when the visual side should lead the composition and you want built-in media framing controls.
 - Use `timeline-slide` and `agenda-slide` for milestones, sections, and chapter overviews that need more structure than bullets.
 - Use `steps-slide` for process, rollout, or tutorial content.
 - Use `text` for semantic headings, paragraphs, inline text, vertical labels, or reusable animation-ready copy blocks.
@@ -116,6 +118,7 @@ Recommendations:
 - Prefer `panel` as the base surface primitive for grouped text, code, media, or mixed content.
 - Prefer `title-slide` over ad hoc hero markup for opening slides or chapter separators.
 - Prefer `two-column-slide` for both general split layouts and media-plus-content layouts; frame the visual side with `panel` when needed.
+- Prefer `media-split-slide` when the deck benefits from a more opinionated media-led split with `plain`, `framed`, or `panel` media presentation.
 - Prefer `timeline-slide`, `steps-slide`, and `agenda-slide` over plain lists when the sequence or hierarchy matters to the talk.
 - Still allow local customization through slots and `class` passthrough when a deck needs light visual tailoring.
 

--- a/src/View/Components/MediaSplitSlide.php
+++ b/src/View/Components/MediaSplitSlide.php
@@ -9,9 +9,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 use WendellAdriel\SlideWire\Support\UiThemeResolver;
 
-/**
- * @deprecated Use TwoColumnSlide and wrap the media side with Panel when needed.
- */
 class MediaSplitSlide extends Component
 {
     public function __construct(

--- a/tests/Feature/UiComponents/LayoutComponentsTest.php
+++ b/tests/Feature/UiComponents/LayoutComponentsTest.php
@@ -43,3 +43,22 @@ BLADE);
         ->toContain('lg:order-2')
         ->toContain('backdrop-blur-xl');
 });
+
+it('normalizes media split slide options to supported defaults', function (): void {
+    $html = Blade::render(<<<'BLADE'
+<x-slidewire::media-split-slide media-position="diagonal" ratio="9:9" media-style="card" gap="xxl">
+    <x-slot:media>
+        <img src="/demo.png" alt="Demo screen" />
+    </x-slot:media>
+    <x-slot:content>
+        <p>Supporting copy</p>
+    </x-slot:content>
+</x-slidewire::media-split-slide>
+BLADE);
+
+    expect($html)
+        ->toContain('lg:grid-cols-2')
+        ->toContain('gap-7')
+        ->not->toContain('lg:order-2')
+        ->not->toContain('backdrop-blur-xl');
+});


### PR DESCRIPTION
This PR restores `media-split-slide` as a supported layout so the package guidance matches the component surface that ships today.

### Approach

- remove the deprecation marker from the media split component
- update the SlideWire skill guidance to describe it as a supported option
- add feature coverage for invalid media split options falling back to supported defaults