### PR TITLE
Fix DTO config serialization for config caching

### DIFF
--- a/src/DTOs/FontConfig.php
+++ b/src/DTOs/FontConfig.php
@@ -17,6 +17,14 @@ final readonly class FontConfig implements Stringable
         public array $weights = [],
     ) {}
 
+    /**
+     * @param  array{source: FontSource, weights: list<int>}  $properties
+     */
+    public static function __set_state(array $properties): self
+    {
+        return new self(...$properties);
+    }
+
     public function __toString(): string
     {
         return $this->source->value;

--- a/src/DTOs/HighlightConfig.php
+++ b/src/DTOs/HighlightConfig.php
@@ -14,4 +14,12 @@ final readonly class HighlightConfig
         public string $font = 'JetBrainsMono',
         public string $fontSize = 'text-base',
     ) {}
+
+    /**
+     * @param  array{enabled: bool, theme: Theme, font: string, fontSize: string}  $properties
+     */
+    public static function __set_state(array $properties): self
+    {
+        return new self(...$properties);
+    }
 }

--- a/src/DTOs/SlidesConfig.php
+++ b/src/DTOs/SlidesConfig.php
@@ -23,4 +23,12 @@ final readonly class SlidesConfig
         public bool $autoSlidePauseOnInteraction = true,
         public HighlightConfig $highlight = new HighlightConfig(fontSize: 'text-base'),
     ) {}
+
+    /**
+     * @param  array{theme: string, showControls: bool, showProgress: bool, showFullscreenButton: bool, keyboard: bool, touch: bool, transition: SlideTransition, transitionDuration: int, transitionSpeed: SlideTransitionSpeed, autoSlide: int, autoSlidePauseOnInteraction: bool, highlight: HighlightConfig}  $properties
+     */
+    public static function __set_state(array $properties): self
+    {
+        return new self(...$properties);
+    }
 }

--- a/src/DTOs/ThemeConfig.php
+++ b/src/DTOs/ThemeConfig.php
@@ -16,6 +16,14 @@ final readonly class ThemeConfig implements Stringable
         public ThemeFont $text,
     ) {}
 
+    /**
+     * @param  array{background: string, highlightTheme: Theme, title: ThemeFont, text: ThemeFont}  $properties
+     */
+    public static function __set_state(array $properties): self
+    {
+        return new self(...$properties);
+    }
+
     public function __toString(): string
     {
         return $this->background;

--- a/src/DTOs/ThemeFont.php
+++ b/src/DTOs/ThemeFont.php
@@ -14,6 +14,14 @@ final readonly class ThemeFont implements Stringable
         public string $size,
     ) {}
 
+    /**
+     * @param  array{font: string, color: string, size: string}  $properties
+     */
+    public static function __set_state(array $properties): self
+    {
+        return new self(...$properties);
+    }
+
     public function __toString(): string
     {
         return implode(' ', array_filter([$this->font, $this->color, $this->size]));

--- a/tests/Unit/ConfigValidatorTest.php
+++ b/tests/Unit/ConfigValidatorTest.php
@@ -92,3 +92,37 @@ it('rejects empty highlight font size', function (): void {
         highlight: new HighlightConfig(fontSize: '  '),
     ));
 })->throws(InvalidArgumentException::class, 'font_size must be a non-empty string');
+
+it('supports var export hydration for slidewire config dto objects', function (): void {
+    $slides = new SlidesConfig(
+        transition: SlideTransition::Fade,
+        transitionSpeed: SlideTransitionSpeed::Fast,
+        highlight: new HighlightConfig(
+            enabled: false,
+            theme: Theme::GithubDark,
+            font: 'FiraCode',
+            fontSize: 'text-sm',
+        ),
+    );
+
+    $theme = new ThemeConfig(
+        background: 'bg-slate-950 text-white',
+        highlightTheme: Theme::GithubDark,
+        title: new ThemeFont('Sora', 'text-white', 'text-5xl'),
+        text: new ThemeFont('Sora', 'text-slate-200', 'text-lg'),
+    );
+
+    $font = new FontConfig(FontSource::Google, [400, 600, 700]);
+
+    /** @var SlidesConfig $rehydratedSlides */
+    $rehydratedSlides = eval('return ' . var_export($slides, true) . ';');
+    /** @var ThemeConfig $rehydratedTheme */
+    $rehydratedTheme = eval('return ' . var_export($theme, true) . ';');
+    /** @var FontConfig $rehydratedFont */
+    $rehydratedFont = eval('return ' . var_export($font, true) . ';');
+
+    expect($rehydratedSlides)
+        ->toEqual($slides)
+        ->and($rehydratedTheme)->toEqual($theme)
+        ->and($rehydratedFont)->toEqual($font);
+});


### PR DESCRIPTION
This fixes Laravel config caching when SlideWire config uses DTO objects. Without this, `config:cache` fails because the DTOs cannot be rehydrated from `var_export()` output.

### Approach
- add `__set_state()` to the config DTOs Laravel serializes during config caching
- add a regression test that round-trips the DTOs through `var_export()` hydration