### PR TITLE
Add markdown and composed deck support

### DIFF
--- a/src/Commands/MakeSlideCommand.php
+++ b/src/Commands/MakeSlideCommand.php
@@ -14,27 +14,54 @@ class MakeSlideCommand extends Command
         {name? : The presentation path, e.g. team/q1-kickoff}
         {--presentation= : The presentation path override}
         {--title= : The first slide title}
+        {--md : Create a standalone Markdown deck}
+        {--multi : Create a multi-file deck}
         {--force : Overwrite existing files}';
 
     protected $description = 'Create a SlideWire presentation scaffold';
 
     public function handle(PresentationPathResolver $resolver): int
     {
-        $presentation = $this->resolvePresentationName();
-        $title = $this->option('title') ?: $this->ask('Presentation title', 'SlideWire Presentation');
-
-        $presentationPath = $resolver->absolutePresentationPath($presentation);
-
-        if (File::exists($presentationPath) && ! (bool) $this->option('force')) {
-            $this->error("Slide scaffold already exists at [{$presentationPath}]. Use --force to overwrite.");
+        if ((bool) $this->option('md') && (bool) $this->option('multi')) {
+            $this->error('The --md and --multi options cannot be combined.');
 
             return self::FAILURE;
         }
 
+        $presentation = $this->resolvePresentationName();
+        $title = $this->option('title') ?: $this->ask('Presentation title', 'SlideWire Presentation');
+
+        $existingPath = $resolver->presentationPath($presentation);
+
+        if ($existingPath !== null && ! (bool) $this->option('force')) {
+            $this->error("Slide scaffold already exists at [{$existingPath}]. Use --force to overwrite.");
+
+            return self::FAILURE;
+        }
+
+        if (is_string($existingPath) && (bool) $this->option('force')) {
+            $this->deletePath($existingPath);
+        }
+
+        if ((bool) $this->option('multi')) {
+            $presentationDirectory = $resolver->firstRoot() . DIRECTORY_SEPARATOR . $presentation;
+
+            $this->createMultiFilePresentation($presentationDirectory, $presentation, $title);
+
+            $this->info("Created SlideWire presentation [{$presentation}] at [{$presentationDirectory}].");
+
+            return self::SUCCESS;
+        }
+
+        $presentationPath = $this->presentationPath($resolver, $presentation, (bool) $this->option('md'));
+
         File::ensureDirectoryExists(dirname($presentationPath));
 
-        $stub = File::get(__DIR__ . '/../../stubs/presentation.stub');
-        $contents = str_replace(['{{ title }}', '{{ presentation }}'], [$title, $presentation], $stub);
+        $stub = (bool) $this->option('md')
+            ? File::get(__DIR__ . '/../../stubs/presentation-markdown.stub')
+            : File::get(__DIR__ . '/../../stubs/presentation.stub');
+
+        $contents = $this->populateStub($stub, $presentation, $title);
 
         File::put($presentationPath, $contents);
 
@@ -52,5 +79,57 @@ class MakeSlideCommand extends Command
         }
 
         return trim((string) $this->ask('Presentation path', 'index'), '/');
+    }
+
+    protected function presentationPath(PresentationPathResolver $resolver, string $presentation, bool $markdown): string
+    {
+        $root = $resolver->firstRoot();
+        $suffix = $markdown ? '.md' : '.blade.php';
+
+        return $root . DIRECTORY_SEPARATOR . $presentation . $suffix;
+    }
+
+    protected function createMultiFilePresentation(string $presentationDirectory, string $presentation, string $title): void
+    {
+        File::ensureDirectoryExists($presentationDirectory);
+
+        File::put(
+            $presentationDirectory . DIRECTORY_SEPARATOR . 'deck.blade.php',
+            File::get(__DIR__ . '/../../stubs/presentation-multi-deck.stub'),
+        );
+
+        File::put(
+            $presentationDirectory . DIRECTORY_SEPARATOR . '01-intro.blade.php',
+            $this->populateStub(
+                File::get(__DIR__ . '/../../stubs/presentation-multi-slide.stub'),
+                $presentation,
+                $title,
+            ),
+        );
+
+        File::put(
+            $presentationDirectory . DIRECTORY_SEPARATOR . '02-markdown.md',
+            $this->populateStub(
+                File::get(__DIR__ . '/../../stubs/presentation-multi-markdown.stub'),
+                $presentation,
+                $title,
+            ),
+        );
+    }
+
+    protected function populateStub(string $stub, string $presentation, string $title): string
+    {
+        return str_replace(['{{ title }}', '{{ presentation }}'], [$title, $presentation], $stub);
+    }
+
+    protected function deletePath(string $path): void
+    {
+        if (File::isDirectory($path)) {
+            File::deleteDirectory($path);
+
+            return;
+        }
+
+        File::delete($path);
     }
 }

--- a/src/SlideWireServiceProvider.php
+++ b/src/SlideWireServiceProvider.php
@@ -12,9 +12,12 @@ use WendellAdriel\SlideWire\Commands\MakeSlideCommand;
 use WendellAdriel\SlideWire\Support\CodeBlockPrecompiler;
 use WendellAdriel\SlideWire\Support\CodeHighlighter;
 use WendellAdriel\SlideWire\Support\EffectiveSettingsResolver;
+use WendellAdriel\SlideWire\Support\MarkdownPresentationParser;
+use WendellAdriel\SlideWire\Support\MarkdownRenderer;
 use WendellAdriel\SlideWire\Support\PresentationCompiler;
 use WendellAdriel\SlideWire\Support\PresentationPathResolver;
 use WendellAdriel\SlideWire\Support\SlideContext;
+use WendellAdriel\SlideWire\Support\SlideIdGenerator;
 use WendellAdriel\SlideWire\Support\ThemeResolver;
 use WendellAdriel\SlideWire\Support\UiThemeResolver;
 
@@ -26,6 +29,9 @@ class SlideWireServiceProvider extends ServiceProvider
 
         $this->app->singleton(PresentationPathResolver::class);
         $this->app->singleton(CodeHighlighter::class);
+        $this->app->singleton(MarkdownRenderer::class);
+        $this->app->singleton(MarkdownPresentationParser::class);
+        $this->app->singleton(SlideIdGenerator::class);
         $this->app->singleton(PresentationCompiler::class);
         $this->app->singleton(EffectiveSettingsResolver::class);
         $this->app->singleton(ThemeResolver::class);

--- a/src/Support/MarkdownPresentationParser.php
+++ b/src/Support/MarkdownPresentationParser.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\SlideWire\Support;
+
+use RuntimeException;
+use WendellAdriel\SlideWire\DTOs\Slide;
+
+class MarkdownPresentationParser
+{
+    public function __construct(
+        protected MarkdownRenderer $renderer,
+        protected SlideIdGenerator $slideIdGenerator,
+    ) {}
+
+    /**
+     * @return array{deck_meta: array<string, string>, slides: array<int, array<int, Slide>>}
+     */
+    public function parse(string $path, string $source): array
+    {
+        $source = str_replace(["\r\n", "\r"], "\n", $source);
+
+        [$deckMeta, $body] = $this->extractFrontmatter($source, $path, 'deck');
+        $segments = $this->splitSlides($body);
+        $slides = [];
+
+        foreach ($segments as $hIndex => $segment) {
+            $slide = $this->parseSlide($path, $segment, $deckMeta, $hIndex);
+
+            if (! $slide instanceof Slide) {
+                continue;
+            }
+
+            $slides[] = [$slide];
+        }
+
+        return ['deck_meta' => $deckMeta, 'slides' => $slides];
+    }
+
+    protected function parseSlide(string $path, string $segment, array $deckMeta, int $hIndex): ?Slide
+    {
+        [$slideMeta, $body] = $this->extractFrontmatter($segment, $path, 'slide');
+        $body = trim($body);
+
+        if ($body === '' && $slideMeta === []) {
+            return null;
+        }
+
+        $presentationTheme = $slideMeta['theme'] ?? $deckMeta['theme'] ?? null;
+        $highlightTheme = $slideMeta['highlight_theme'] ?? $deckMeta['highlight_theme'] ?? null;
+        $html = trim($this->renderer->toHtml($body, $presentationTheme, $highlightTheme));
+
+        return new Slide(
+            id: $this->slideIdGenerator->fromPath($path, $hIndex, 0),
+            html: $html,
+            meta: $slideMeta,
+            fragments: $this->fragmentCount($html),
+            h: $hIndex,
+            v: 0,
+        );
+    }
+
+    /**
+     * @return array{0: array<string, string>, 1: string}
+     */
+    protected function extractFrontmatter(string $source, string $path, string $context): array
+    {
+        $trimmedSource = ltrim($source, "\n");
+
+        if (! str_starts_with($trimmedSource, "---\n") && trim((string) strtok($trimmedSource, "\n")) !== '---') {
+            return [[], $source];
+        }
+
+        $lines = explode("\n", $trimmedSource);
+
+        if (($lines[0] ?? null) !== '---') {
+            throw new RuntimeException("Malformed {$context} frontmatter in markdown presentation [{$path}].");
+        }
+
+        $frontmatterLines = [];
+        $closingIndex = null;
+
+        foreach ($lines as $index => $line) {
+            if ($index === 0) {
+                continue;
+            }
+
+            if ($line === '---') {
+                $closingIndex = $index;
+
+                break;
+            }
+
+            $frontmatterLines[] = $line;
+        }
+
+        if ($closingIndex === null) {
+            throw new RuntimeException("Malformed {$context} frontmatter in markdown presentation [{$path}].");
+        }
+
+        $body = implode("\n", array_slice($lines, $closingIndex + 1));
+
+        return [$this->parseFrontmatter($frontmatterLines, $path, $context), ltrim($body, "\n")];
+    }
+
+    /**
+     * @param  array<int, string>  $lines
+     * @return array<string, string>
+     */
+    protected function parseFrontmatter(array $lines, string $path, string $context): array
+    {
+        $meta = [];
+
+        foreach ($lines as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+
+            if (preg_match('/^\s+/', $line) === 1 || preg_match('/^\s*-\s*/', $line) === 1) {
+                throw new RuntimeException("Unsupported non-scalar {$context} frontmatter value in markdown presentation [{$path}].");
+            }
+
+            if (preg_match('/^([A-Za-z0-9_-]+):\s*(.*)$/', $line, $matches) !== 1) {
+                throw new RuntimeException("Malformed {$context} frontmatter in markdown presentation [{$path}].");
+            }
+
+            $value = trim($matches[2]);
+
+            if ($value !== '' && preg_match('/^[\[{]/', $value) === 1) {
+                throw new RuntimeException("Unsupported non-scalar {$context} frontmatter value in markdown presentation [{$path}].");
+            }
+
+            if (
+                strlen($value) >= 2
+                && (($value[0] === '"' && $value[strlen($value) - 1] === '"') || ($value[0] === '\'' && $value[strlen($value) - 1] === '\''))
+            ) {
+                $value = substr($value, 1, -1);
+            }
+
+            $meta[$this->normalizeMetaKey($matches[1])] = $value;
+        }
+
+        return $meta;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function splitSlides(string $markdown): array
+    {
+        if (trim($markdown) === '') {
+            return [];
+        }
+
+        $segments = [];
+        $buffer = [];
+        $inFence = false;
+
+        foreach (explode("\n", $markdown) as $line) {
+            if ($this->isFenceDelimiter($line)) {
+                $inFence = ! $inFence;
+            }
+
+            if (! $inFence && trim($line) === '<!-- slide -->') {
+                $segments[] = implode("\n", $buffer);
+                $buffer = [];
+
+                continue;
+            }
+
+            $buffer[] = $line;
+        }
+
+        $segments[] = implode("\n", $buffer);
+
+        return $segments;
+    }
+
+    protected function isFenceDelimiter(string $line): bool
+    {
+        return preg_match('/^\s*```/', $line) === 1;
+    }
+
+    protected function normalizeMetaKey(string $key): string
+    {
+        return str_replace('-', '_', strtolower(trim($key)));
+    }
+
+    protected function fragmentCount(string $html): int
+    {
+        preg_match_all('/data-fragment(?:-index)?="?(\d+)?"?/', $html, $matches);
+
+        if ($matches[0] === []) {
+            return 0;
+        }
+
+        $indices = array_filter($matches[1], static fn (string $value): bool => $value !== '');
+
+        if ($indices === []) {
+            return count($matches[0]);
+        }
+
+        return max(array_map(intval(...), $indices)) + 1;
+    }
+}

--- a/src/Support/MarkdownRenderer.php
+++ b/src/Support/MarkdownRenderer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\SlideWire\Support;
+
+use Illuminate\Support\Str;
+use Phiki\Theme\Theme;
+
+class MarkdownRenderer
+{
+    public function __construct(protected CodeHighlighter $highlighter) {}
+
+    public function toHtml(string $markdown, ?string $presentationTheme = null, Theme|string|null $highlightTheme = null, ?string $size = null): string
+    {
+        $markdown = CodeBlockPrecompiler::decode($markdown);
+
+        $withHighlightedCode = $this->highlighter->replaceCodeBlocks(
+            $markdown,
+            $highlightTheme,
+            $presentationTheme,
+            null,
+            $size,
+        );
+
+        return Str::markdown($withHighlightedCode);
+    }
+}

--- a/src/Support/PresentationCompiler.php
+++ b/src/Support/PresentationCompiler.php
@@ -7,17 +7,23 @@ namespace WendellAdriel\SlideWire\Support;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Livewire\Component as LivewireComponent;
 use Livewire\Drawer\BaseUtils as LivewireBaseUtils;
 use Livewire\Drawer\Utils as LivewireUtils;
 use ReflectionMethod;
 use RuntimeException;
+use SplFileInfo;
 use Throwable;
 use WendellAdriel\SlideWire\DTOs\Slide;
 
 class PresentationCompiler
 {
-    public function __construct(protected PresentationPathResolver $resolver) {}
+    public function __construct(
+        protected PresentationPathResolver $resolver,
+        protected MarkdownPresentationParser $markdownParser,
+        protected SlideIdGenerator $slideIdGenerator,
+    ) {}
 
     /**
      * @return array{deck_meta: array<string, string>, slides: array<int, array<int, Slide>>}
@@ -32,7 +38,19 @@ class PresentationCompiler
             return ['deck_meta' => [], 'slides' => []];
         }
 
-        return $this->compileFile($path);
+        return $this->compilePath($path);
+    }
+
+    /**
+     * @return array{deck_meta: array<string, string>, slides: array<int, array<int, Slide>>}
+     */
+    public function compilePath(string $path, bool $allowDeckWrapper = true): array
+    {
+        if (File::isDirectory($path)) {
+            return $this->compileDirectory($path);
+        }
+
+        return $this->compileFile($path, $allowDeckWrapper);
     }
 
     /**
@@ -57,7 +75,7 @@ class PresentationCompiler
      *
      * @throws RuntimeException when the file cannot be read or rendered
      */
-    protected function compileFile(string $path): array
+    protected function compileFile(string $path, bool $allowDeckWrapper = true): array
     {
         if (! File::exists($path)) {
             throw new RuntimeException("Presentation file not found: {$path}");
@@ -69,6 +87,10 @@ class PresentationCompiler
             throw new RuntimeException("Failed to read presentation file [{$path}]: {$e->getMessage()}", $e->getCode(), previous: $e);
         }
 
+        if (str_ends_with($path, '.md')) {
+            return $this->markdownParser->parse($path, $content);
+        }
+
         try {
             $html = $this->renderPresentation($path, $content);
         } catch (Throwable $e) {
@@ -78,6 +100,10 @@ class PresentationCompiler
         $deckMeta = $this->extractDeckMeta($html);
 
         $deckInner = $this->extractDeckInner($html);
+
+        if (! $allowDeckWrapper && $deckInner !== null) {
+            throw new RuntimeException("Composed presentation part [{$path}] cannot contain a deck wrapper.");
+        }
 
         if ($deckInner === null) {
             return ['deck_meta' => $deckMeta, 'slides' => $this->parseFlatSlides($html, $path)];
@@ -107,6 +133,44 @@ class PresentationCompiler
         }
 
         return $view->render();
+    }
+
+    /**
+     * @return array{deck_meta: array<string, string>, slides: array<int, array<int, Slide>>}
+     */
+    protected function compileDirectory(string $path): array
+    {
+        $deckMeta = [];
+        $deckPath = $path . DIRECTORY_SEPARATOR . 'deck.blade.php';
+
+        if (File::exists($deckPath)) {
+            $deckMeta = $this->compileFile($deckPath)['deck_meta'];
+        }
+
+        $partPaths = collect(File::files($path))
+            ->map(static fn (SplFileInfo $file): string => $file->getPathname())
+            ->filter(fn (string $filePath): bool => $this->isComposablePart($filePath))
+            ->sort()
+            ->values()
+            ->all();
+
+        if ($partPaths === []) {
+            return ['deck_meta' => $deckMeta, 'slides' => []];
+        }
+
+        $columns = [];
+        $hIndex = 0;
+
+        foreach ($partPaths as $partPath) {
+            $compiled = $this->compileFile($partPath, allowDeckWrapper: false);
+
+            foreach ($this->flattenSlides($compiled['slides']) as $slide) {
+                $columns[] = [$slide->withCoordinates($hIndex, 0)];
+                ++$hIndex;
+            }
+        }
+
+        return ['deck_meta' => $deckMeta, 'slides' => $columns];
     }
 
     protected function isLivewireSingleFileComponent(string $content): bool
@@ -242,7 +306,7 @@ class PresentationCompiler
         $innerHtml = trim($match[2] ?? '');
 
         return new Slide(
-            id: $this->slideId($path, $hIndex, $vIndex),
+            id: $this->slideIdGenerator->fromPath($path, $hIndex, $vIndex),
             html: $innerHtml,
             meta: $this->extractMetaFromAttributes($attributes),
             fragments: $this->fragmentCount($innerHtml),
@@ -350,17 +414,14 @@ class PresentationCompiler
         return '/<section\b([^>]*class=(?:"[^"]*slidewire-deck[^"]*"|\'[^\']*slidewire-deck[^\']*\')[^>]*)>/is';
     }
 
-    protected function slideId(string $path, int $hIndex, int $vIndex): string
+    protected function isComposablePart(string $path): bool
     {
-        $basename = pathinfo($path, PATHINFO_BASENAME);
-        $name = str_ends_with($basename, '.blade.php')
-            ? substr($basename, 0, -10)
-            : pathinfo($path, PATHINFO_FILENAME);
+        $filename = basename($path);
 
-        if ($vIndex > 0) {
-            return "{$name}-{$hIndex}-{$vIndex}";
+        if ($filename === 'deck.blade.php') {
+            return false;
         }
 
-        return "{$name}-{$hIndex}";
+        return Str::endsWith($filename, ['.blade.php', '.md']);
     }
 }

--- a/src/Support/PresentationPathResolver.php
+++ b/src/Support/PresentationPathResolver.php
@@ -14,10 +14,22 @@ class PresentationPathResolver
         $normalized = $this->normalizePresentationName($presentation);
 
         foreach ($this->roots() as $root) {
-            $candidate = "{$root}" . DIRECTORY_SEPARATOR . "{$normalized}.blade.php";
+            $bladeCandidate = "{$root}" . DIRECTORY_SEPARATOR . "{$normalized}.blade.php";
 
-            if (File::exists($candidate)) {
-                return $candidate;
+            if (File::exists($bladeCandidate)) {
+                return $bladeCandidate;
+            }
+
+            $markdownCandidate = "{$root}" . DIRECTORY_SEPARATOR . "{$normalized}.md";
+
+            if (File::exists($markdownCandidate)) {
+                return $markdownCandidate;
+            }
+
+            $directoryCandidate = "{$root}" . DIRECTORY_SEPARATOR . $normalized;
+
+            if (File::isDirectory($directoryCandidate)) {
+                return $directoryCandidate;
             }
         }
 
@@ -40,6 +52,10 @@ class PresentationPathResolver
             return null;
         }
 
+        if (File::isDirectory($path)) {
+            return $path;
+        }
+
         return dirname($path);
     }
 
@@ -48,6 +64,11 @@ class PresentationPathResolver
         $roots = $this->roots();
 
         return $roots[0] ?? resource_path('views/pages/slides');
+    }
+
+    public function roots(): array
+    {
+        return array_values(array_filter(config('slidewire.presentation_roots', []), is_string(...)));
     }
 
     protected function normalizePresentationName(string $presentation): string
@@ -66,10 +87,5 @@ class PresentationPathResolver
         }
 
         return $normalized;
-    }
-
-    protected function roots(): array
-    {
-        return array_values(array_filter(config('slidewire.presentation_roots', []), is_string(...)));
     }
 }

--- a/src/Support/SlideIdGenerator.php
+++ b/src/Support/SlideIdGenerator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WendellAdriel\SlideWire\Support;
+
+class SlideIdGenerator
+{
+    public function __construct(protected PresentationPathResolver $resolver) {}
+
+    public function fromPath(string $path, int $hIndex, int $vIndex): string
+    {
+        $name = $this->normalizedName($path);
+
+        if ($vIndex > 0) {
+            return "{$name}-{$hIndex}-{$vIndex}";
+        }
+
+        return "{$name}-{$hIndex}";
+    }
+
+    protected function normalizedName(string $path): string
+    {
+        $normalizedPath = str_replace('\\', '/', $path);
+
+        foreach ($this->resolver->roots() as $root) {
+            $normalizedRoot = rtrim(str_replace('\\', '/', $root), '/');
+
+            if (str_starts_with($normalizedPath, $normalizedRoot . '/')) {
+                $relative = substr($normalizedPath, strlen($normalizedRoot) + 1);
+
+                return $this->stripExtension($relative);
+            }
+        }
+
+        return $this->stripExtension(basename($normalizedPath));
+    }
+
+    protected function stripExtension(string $path): string
+    {
+        $path = str_replace(['.blade.php', '.md'], '', $path);
+
+        return str_replace(['/', '\\', '.'], '-', trim($path, '/'));
+    }
+}

--- a/src/View/Components/Markdown.php
+++ b/src/View/Components/Markdown.php
@@ -6,16 +6,14 @@ namespace WendellAdriel\SlideWire\View\Components;
 
 use Closure;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Str;
 use Illuminate\View\Component;
-use WendellAdriel\SlideWire\Support\CodeBlockPrecompiler;
-use WendellAdriel\SlideWire\Support\CodeHighlighter;
+use WendellAdriel\SlideWire\Support\MarkdownRenderer;
 use WendellAdriel\SlideWire\Support\SlideContext;
 
 class Markdown extends Component
 {
     public function __construct(
-        protected CodeHighlighter $highlighter,
+        protected MarkdownRenderer $renderer,
         protected SlideContext $context,
         public ?string $size = null,
     ) {}
@@ -27,16 +25,11 @@ class Markdown extends Component
 
     public function toHtml(string $markdown): string
     {
-        $markdown = CodeBlockPrecompiler::decode($markdown);
-
-        $withHighlightedCode = $this->highlighter->replaceCodeBlocks(
+        return $this->renderer->toHtml(
             $markdown,
-            $this->context->highlightTheme(),
             $this->context->presentationTheme(),
-            null,
+            $this->context->highlightTheme(),
             $this->size,
         );
-
-        return Str::markdown($withHighlightedCode);
     }
 }

--- a/stubs/presentation-markdown.stub
+++ b/stubs/presentation-markdown.stub
@@ -1,0 +1,27 @@
+---
+theme: black
+transition: fade
+---
+
+# {{ title }}
+
+Presentation key: `{{ presentation }}`
+
+- Use the arrow keys, click, or swipe to navigate.
+- Add deck-level metadata with frontmatter.
+
+<!-- slide -->
+
+---
+theme: white
+---
+
+## Markdown Support
+
+- Write a full deck in Markdown.
+- Split slides with `<!-- slide -->`.
+- Add code fences for syntax highlighting.
+
+```php
+Route::slidewire('/slides/demo', '{{ presentation }}');
+```

--- a/stubs/presentation-multi-deck.stub
+++ b/stubs/presentation-multi-deck.stub
@@ -1,0 +1,1 @@
+<x-slidewire::deck theme="black" transition="fade"></x-slidewire::deck>

--- a/stubs/presentation-multi-markdown.stub
+++ b/stubs/presentation-multi-markdown.stub
@@ -1,0 +1,13 @@
+---
+theme: white
+---
+
+## Markdown Slide
+
+- Use Blade parts for layout-heavy slides.
+- Use Markdown parts for prose-heavy content.
+- Mix both in a composed deck.
+
+```php
+Route::slidewire('/slides/demo', '{{ presentation }}');
+```

--- a/stubs/presentation-multi-slide.stub
+++ b/stubs/presentation-multi-slide.stub
@@ -1,0 +1,11 @@
+<x-slidewire::slide class="bg-slate-900 text-white">
+    <div class="mx-auto max-w-5xl space-y-6">
+        <h1 class="text-4xl font-bold tracking-tight">{{ title }}</h1>
+        <p class="text-lg text-slate-200">
+            Presentation key: <strong>{{ presentation }}</strong>
+        </p>
+        <x-slidewire::fragment>
+            <p class="text-base text-slate-300">This deck is split into multiple files for easier composition.</p>
+        </x-slidewire::fragment>
+    </div>
+</x-slidewire::slide>

--- a/tests/Browser/MarkdownAndCompositionBrowserTest.php
+++ b/tests/Browser/MarkdownAndCompositionBrowserTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('navigates a standalone markdown deck in the browser', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/browser-markdown', 'markdown/standalone');
+
+    $page = visit('/slides/browser-markdown');
+
+    $page->waitForText('Welcome to SlideWire.')
+        ->assertSee('Welcome to SlideWire.')
+        ->assertNoJavaScriptErrors();
+
+    expect($page->script("document.querySelector('.slidewire-frame.is-active h1').textContent.trim()"))
+        ->toBe('Intro')
+        ->and($page->script("document.querySelector('.slidewire-controls')"))
+        ->toBeNull();
+
+    $page->script("document.querySelector('.slidewire-stage').click()");
+    $page->wait(0.5);
+
+    expect($page->script("document.querySelector('.slidewire-frame.is-active h2').textContent.trim()"))
+        ->toBe('Code')
+        ->and($page->script('window.location.hash'))
+        ->toBe('#/slide/2')
+        ->and($page->script("document.querySelector('.slidewire-frame.is-active').dataset.theme"))
+        ->toBe('white')
+        ->and($page->script("document.querySelector('.slidewire-frame.is-active').dataset.autoSlide"))
+        ->toBe('3000');
+
+    $page->assertNoJavaScriptErrors();
+})->group('browser');
+
+it('navigates a composed presentation in the browser and preserves ordering', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/browser-composed', 'composed/product-launch');
+
+    $page = visit('/slides/browser-composed');
+
+    $page->waitForText('Launch Intro')
+        ->assertSee('Launch Intro')
+        ->assertNoJavaScriptErrors();
+
+    expect($page->script("document.querySelector('.slidewire-frame.is-active h1').textContent.trim()"))
+        ->toBe('Launch Intro')
+        ->and($page->script("document.querySelector('.slidewire-shell').className"))
+        ->toContain('bg-slate-900');
+
+    $page->script("document.querySelector('.slidewire-stage').click()");
+    $page->wait(0.5);
+
+    expect($page->script("document.querySelector('.slidewire-frame.is-active h2').textContent.trim()"))
+        ->toBe('Live Demo')
+        ->and($page->script('window.location.hash'))
+        ->toBe('#/slide/2');
+
+    $page->script("document.querySelector('.slidewire-stage').click()");
+    $page->wait(0.5);
+
+    expect($page->script("document.querySelector('.slidewire-frame.is-active h2').textContent.trim()"))
+        ->toBe('Roadmap')
+        ->and($page->script('window.location.hash'))
+        ->toBe('#/slide/3');
+
+    $page->assertNoJavaScriptErrors();
+})->group('browser');

--- a/tests/Feature/ComposedPresentationDeckTest.php
+++ b/tests/Feature/ComposedPresentationDeckTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('renders a route-backed composed presentation in the expected order', function (): void {
+    Route::slidewire('/slides/composed-launch', 'composed/product-launch');
+
+    test()->get('/slides/composed-launch')
+        ->assertSuccessful()
+        ->assertSee('Launch Intro')
+        ->assertSee('Live Demo')
+        ->assertSee('Roadmap');
+});
+
+it('applies deck defaults from the composed deck wrapper', function (): void {
+    Route::slidewire('/slides/composed-theme', 'composed/product-launch');
+
+    $content = test()->get('/slides/composed-theme')->getContent();
+
+    expect($content)->toContain('slidewire-theme-black')
+        ->and($content)->toContain('data-transition="fade"');
+});
+
+it('surfaces nested deck wrapper failures for composed presentations', function (): void {
+    Route::slidewire('/slides/composed-invalid', 'composed/invalid-nested-deck');
+
+    test()->get('/slides/composed-invalid')->assertStatus(500);
+});

--- a/tests/Feature/MakeSlideCommandTest.php
+++ b/tests/Feature/MakeSlideCommandTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 
 it('generates a presentation scaffold', function (): void {
-    $root = config('slidewire.presentation_roots.0');
+    $root = slidewireScaffoldRoot();
     $target = $root . '/team/q1-kickoff.blade.php';
 
     File::deleteDirectory($root . '/team');
@@ -23,3 +23,68 @@ it('generates a presentation scaffold', function (): void {
         ->and($contents)->toContain('use Livewire\\Component;')
         ->and($contents)->toContain('new class extends Component');
 });
+
+it('generates a standalone markdown presentation scaffold', function (): void {
+    $root = slidewireScaffoldRoot();
+    $target = $root . '/team/markdown-kickoff.md';
+
+    File::deleteDirectory($root . '/team');
+
+    Artisan::call('make:slidewire', [
+        'name' => 'team/markdown-kickoff',
+        '--title' => 'Markdown Kickoff',
+        '--md' => true,
+    ]);
+
+    $contents = File::get($target);
+
+    expect(File::exists($target))->toBeTrue()
+        ->and($contents)->toContain('# Markdown Kickoff')
+        ->and($contents)->toContain('<!-- slide -->')
+        ->and($contents)->toContain("Route::slidewire('/slides/demo', 'team/markdown-kickoff');");
+});
+
+it('generates a multi-file presentation scaffold', function (): void {
+    $root = slidewireScaffoldRoot();
+    $target = $root . '/team/multi-kickoff';
+
+    File::deleteDirectory($root . '/team');
+
+    Artisan::call('make:slidewire', [
+        'name' => 'team/multi-kickoff',
+        '--title' => 'Multi Kickoff',
+        '--multi' => true,
+    ]);
+
+    expect(File::isDirectory($target))->toBeTrue()
+        ->and(File::exists($target . '/deck.blade.php'))->toBeTrue()
+        ->and(File::exists($target . '/01-intro.blade.php'))->toBeTrue()
+        ->and(File::exists($target . '/02-markdown.md'))->toBeTrue()
+        ->and(File::get($target . '/01-intro.blade.php'))->toContain('Multi Kickoff')
+        ->and(File::get($target . '/02-markdown.md'))->toContain('## Markdown Slide');
+});
+
+it('rejects combining markdown and multi-file scaffolding options', function (): void {
+    slidewireScaffoldRoot();
+
+    $exitCode = Artisan::call('make:slidewire', [
+        'name' => 'team/invalid-kickoff',
+        '--md' => true,
+        '--multi' => true,
+    ]);
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('cannot be combined');
+});
+
+function slidewireScaffoldRoot(): string
+{
+    $root = sys_get_temp_dir() . '/slidewire-make-command-tests';
+
+    File::deleteDirectory($root);
+    File::ensureDirectoryExists($root);
+
+    config()->set('slidewire.presentation_roots', [$root]);
+
+    return $root;
+}

--- a/tests/Feature/MarkdownDeckPresentationTest.php
+++ b/tests/Feature/MarkdownDeckPresentationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('renders a route-backed markdown presentation', function (): void {
+    Route::slidewire('/slides/markdown-standalone', 'markdown/standalone');
+
+    test()->get('/slides/markdown-standalone')
+        ->assertSuccessful()
+        ->assertSee('Welcome to SlideWire.')
+        ->assertSee('phiki')
+        ->assertDontSee('Previous slide');
+});
+
+it('applies deck and slide metadata from markdown presentations to rendered output', function (): void {
+    Route::slidewire('/slides/markdown-meta', 'markdown/standalone');
+
+    $content = test()->get('/slides/markdown-meta')->getContent();
+
+    expect($content)->toContain('slidewire-theme-black')
+        ->and($content)->toContain('slidewire-theme-white')
+        ->and($content)->toContain('data-auto-slide="3000"');
+});
+
+it('returns the existing 404 behavior for empty markdown presentations', function (): void {
+    Route::slidewire('/slides/markdown-empty', 'markdown/standalone-empty');
+
+    test()->get('/slides/markdown-empty')->assertNotFound();
+});
+
+it('surfaces invalid markdown compile failures clearly', function (): void {
+    Route::slidewire('/slides/markdown-invalid', 'markdown/standalone-invalid-frontmatter');
+
+    test()->get('/slides/markdown-invalid')->assertStatus(500);
+});

--- a/tests/Unit/MarkdownPresentationCompilerTest.php
+++ b/tests/Unit/MarkdownPresentationCompilerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use WendellAdriel\SlideWire\Support\PresentationCompiler;
+
+it('compiles a single-slide markdown deck into one slide', function (): void {
+    $compiled = app(PresentationCompiler::class)->compile('markdown/single-slide');
+    $slides = app(PresentationCompiler::class)->flattenSlides($compiled['slides']);
+
+    expect($compiled['deck_meta'])->toBe([])
+        ->and($slides)->toHaveCount(1)
+        ->and($slides[0]->id)->toBe('markdown-single-slide-0')
+        ->and($slides[0]->html)->toContain('<h1>Single Slide</h1>')
+        ->and($slides[0]->html)->toContain('<li>One</li>');
+});
+
+it('compiles a multi-slide markdown deck with deck and slide metadata', function (): void {
+    $compiler = app(PresentationCompiler::class);
+    $compiled = $compiler->compile('markdown/standalone');
+    $slides = $compiler->flattenSlides($compiled['slides']);
+
+    expect($compiled['deck_meta'])->toMatchArray([
+        'theme' => 'black',
+        'transition' => 'fade',
+        'highlight_theme' => 'catppuccin-mocha',
+        'show_controls' => 'false',
+    ])
+        ->and($slides)->toHaveCount(2)
+        ->and($slides[0]->html)->toContain('<h1>Intro</h1>')
+        ->and($slides[0]->html)->toContain('<p>Welcome to SlideWire.</p>')
+        ->and($slides[1]->meta)->toMatchArray([
+            'theme' => 'white',
+            'auto_slide' => '3000',
+        ])
+        ->and($slides[1]->html)->toContain('<h2>Code</h2>')
+        ->and($slides[1]->html)->toContain('phiki');
+});
+
+it('ignores slide separators inside fenced code blocks', function (): void {
+    $compiled = app(PresentationCompiler::class)->compile('markdown/code-fence-separator');
+    $slides = app(PresentationCompiler::class)->flattenSlides($compiled['slides']);
+
+    expect($slides)->toHaveCount(2)
+        ->and($slides[0]->html)->toContain('language-html')
+        ->and($slides[1]->html)->toContain('<h2>Actual Slide</h2>');
+});
+
+it('returns no slides for an empty markdown deck', function (): void {
+    $compiled = app(PresentationCompiler::class)->compile('markdown/standalone-empty');
+
+    expect($compiled['deck_meta'])->toMatchArray(['theme' => 'black'])
+        ->and($compiled['slides'])->toBe([]);
+});
+
+it('rejects malformed markdown frontmatter with a clear exception', function (): void {
+    app(PresentationCompiler::class)->compile('markdown/standalone-invalid-frontmatter');
+})->throws(RuntimeException::class, 'Malformed deck frontmatter');
+
+it('rejects unsupported non-scalar markdown frontmatter values', function (): void {
+    app(PresentationCompiler::class)->compile('markdown/standalone-invalid-non-scalar');
+})->throws(RuntimeException::class, 'Unsupported non-scalar deck frontmatter value');

--- a/tests/Unit/PresentationCompositionCompilerTest.php
+++ b/tests/Unit/PresentationCompositionCompilerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use WendellAdriel\SlideWire\Support\PresentationCompiler;
+
+it('compiles blade partial includes inside a deck', function (): void {
+    $compiled = app(PresentationCompiler::class)->compile('composed/includes');
+    $slides = app(PresentationCompiler::class)->flattenSlides($compiled['slides']);
+
+    expect($compiled['slides'])->toHaveCount(3)
+        ->and($compiled['slides'][1])->toHaveCount(2)
+        ->and($slides)->toHaveCount(4)
+        ->and($slides[0]->html)->toContain('Included Intro')
+        ->and($slides[1]->html)->toContain('Included Stack Top')
+        ->and($slides[2]->html)->toContain('Included Stack Bottom')
+        ->and($slides[3]->html)->toContain('Included Outro');
+});
+
+it('compiles directory-backed composed decks in lexicographic order', function (): void {
+    $compiler = app(PresentationCompiler::class);
+    $compiled = $compiler->compile('composed/product-launch');
+    $slides = $compiler->flattenSlides($compiled['slides']);
+
+    expect($compiled['deck_meta'])->toMatchArray([
+        'theme' => 'black',
+        'transition' => 'fade',
+    ])
+        ->and($slides)->toHaveCount(3)
+        ->and($slides[0]->html)->toContain('Launch Intro')
+        ->and($slides[1]->html)->toContain('Live Demo')
+        ->and($slides[2]->html)->toContain('Roadmap')
+        ->and($slides[0]->h)->toBe(0)
+        ->and($slides[1]->h)->toBe(1)
+        ->and($slides[2]->h)->toBe(2);
+});
+
+it('assigns stable unique ids to slides in composed decks', function (): void {
+    $slides = app(PresentationCompiler::class)->flattenSlides(
+        app(PresentationCompiler::class)->compile('composed/product-launch')['slides'],
+    );
+
+    $ids = array_map(fn (WendellAdriel\SlideWire\DTOs\Slide $slide): string => $slide->id, $slides);
+
+    expect($ids)->toBe([
+        'composed-product-launch-01-intro-0',
+        'composed-product-launch-02-demo-0',
+        'composed-product-launch-03-roadmap-0',
+    ])
+        ->and(count($ids))->toBe(count(array_unique($ids)));
+});
+
+it('rejects nested deck wrappers in composed presentation parts', function (): void {
+    app(PresentationCompiler::class)->compile('composed/invalid-nested-deck');
+})->throws(RuntimeException::class, 'cannot contain a deck wrapper');

--- a/tests/Unit/PresentationPathResolverExpandedTest.php
+++ b/tests/Unit/PresentationPathResolverExpandedTest.php
@@ -25,6 +25,38 @@ it('returns null for non-existent presentations', function (): void {
     expect($resolver->presentationPath('non-existent-deck'))->toBeNull();
 });
 
+it('resolves markdown presentations when no blade file exists', function (): void {
+    $resolver = app(PresentationPathResolver::class);
+
+    expect($resolver->presentationPath('markdown/standalone'))
+        ->toBeString()
+        ->toEndWith('markdown/standalone.md');
+});
+
+it('prefers blade presentations over markdown files with the same name', function (): void {
+    $resolver = app(PresentationPathResolver::class);
+
+    expect($resolver->presentationPath('markdown/standalone-blade-precedence'))
+        ->toBeString()
+        ->toEndWith('markdown/standalone-blade-precedence.blade.php');
+});
+
+it('resolves nested markdown presentation paths', function (): void {
+    $resolver = app(PresentationPathResolver::class);
+
+    expect($resolver->presentationPath('markdown/nested/showcase'))
+        ->toBeString()
+        ->toEndWith('markdown/nested/showcase.md');
+});
+
+it('resolves presentation directories after checking file-based sources', function (): void {
+    $resolver = app(PresentationPathResolver::class);
+
+    expect($resolver->presentationPath('composed/product-launch'))
+        ->toBeString()
+        ->toEndWith('composed/product-launch');
+});
+
 it('resolves nested presentation paths', function (): void {
     $resolver = app(PresentationPathResolver::class);
     $path = $resolver->presentationPath('team/q1-kickoff');

--- a/tests/fixtures/views/pages/slides/composed/includes.blade.php
+++ b/tests/fixtures/views/pages/slides/composed/includes.blade.php
@@ -1,0 +1,7 @@
+<x-slidewire::deck theme="black">
+    @include('pages.slides.composed.partials.intro')
+    @include('pages.slides.composed.partials.stack')
+    <x-slidewire::slide>
+        <h2>Included Outro</h2>
+    </x-slidewire::slide>
+</x-slidewire::deck>

--- a/tests/fixtures/views/pages/slides/composed/invalid-nested-deck/01-bad.blade.php
+++ b/tests/fixtures/views/pages/slides/composed/invalid-nested-deck/01-bad.blade.php
@@ -1,0 +1,5 @@
+<x-slidewire::deck>
+    <x-slidewire::slide>
+        <h1>Bad Nested Deck</h1>
+    </x-slidewire::slide>
+</x-slidewire::deck>

--- a/tests/fixtures/views/pages/slides/composed/partials/intro.blade.php
+++ b/tests/fixtures/views/pages/slides/composed/partials/intro.blade.php
@@ -1,0 +1,3 @@
+<x-slidewire::slide>
+    <h1>Included Intro</h1>
+</x-slidewire::slide>

--- a/tests/fixtures/views/pages/slides/composed/partials/stack.blade.php
+++ b/tests/fixtures/views/pages/slides/composed/partials/stack.blade.php
@@ -1,0 +1,9 @@
+<x-slidewire::vertical-slide>
+    <x-slidewire::slide>
+        <h2>Included Stack Top</h2>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide>
+        <h2>Included Stack Bottom</h2>
+    </x-slidewire::slide>
+</x-slidewire::vertical-slide>

--- a/tests/fixtures/views/pages/slides/composed/product-launch/01-intro.blade.php
+++ b/tests/fixtures/views/pages/slides/composed/product-launch/01-intro.blade.php
@@ -1,0 +1,3 @@
+<x-slidewire::slide>
+    <h1>Launch Intro</h1>
+</x-slidewire::slide>

--- a/tests/fixtures/views/pages/slides/composed/product-launch/02-demo.md
+++ b/tests/fixtures/views/pages/slides/composed/product-launch/02-demo.md
@@ -1,0 +1,10 @@
+---
+theme: white
+auto-slide: 2500
+---
+
+## Live Demo
+
+```php
+echo 'ship it';
+```

--- a/tests/fixtures/views/pages/slides/composed/product-launch/03-roadmap.blade.php
+++ b/tests/fixtures/views/pages/slides/composed/product-launch/03-roadmap.blade.php
@@ -1,0 +1,3 @@
+<x-slidewire::slide>
+    <h2>Roadmap</h2>
+</x-slidewire::slide>

--- a/tests/fixtures/views/pages/slides/composed/product-launch/deck.blade.php
+++ b/tests/fixtures/views/pages/slides/composed/product-launch/deck.blade.php
@@ -1,0 +1,1 @@
+<x-slidewire::deck theme="black" transition="fade"></x-slidewire::deck>

--- a/tests/fixtures/views/pages/slides/markdown/code-fence-separator.md
+++ b/tests/fixtures/views/pages/slides/markdown/code-fence-separator.md
@@ -1,0 +1,9 @@
+# Code Fence Marker
+
+```html
+<!-- slide -->
+```
+
+<!-- slide -->
+
+## Actual Slide

--- a/tests/fixtures/views/pages/slides/markdown/nested/showcase.md
+++ b/tests/fixtures/views/pages/slides/markdown/nested/showcase.md
@@ -1,0 +1,1 @@
+# Nested Markdown Showcase

--- a/tests/fixtures/views/pages/slides/markdown/single-slide.md
+++ b/tests/fixtures/views/pages/slides/markdown/single-slide.md
@@ -1,0 +1,6 @@
+# Single Slide
+
+Welcome to the markdown compiler.
+
+- One
+- Two

--- a/tests/fixtures/views/pages/slides/markdown/standalone-blade-precedence.blade.php
+++ b/tests/fixtures/views/pages/slides/markdown/standalone-blade-precedence.blade.php
@@ -1,0 +1,3 @@
+<x-slidewire::slide>
+    <h1>Blade Wins</h1>
+</x-slidewire::slide>

--- a/tests/fixtures/views/pages/slides/markdown/standalone-blade-precedence.md
+++ b/tests/fixtures/views/pages/slides/markdown/standalone-blade-precedence.md
@@ -1,0 +1,1 @@
+# Markdown Loses

--- a/tests/fixtures/views/pages/slides/markdown/standalone-empty.md
+++ b/tests/fixtures/views/pages/slides/markdown/standalone-empty.md
@@ -1,0 +1,3 @@
+---
+theme: black
+---

--- a/tests/fixtures/views/pages/slides/markdown/standalone-invalid-frontmatter.md
+++ b/tests/fixtures/views/pages/slides/markdown/standalone-invalid-frontmatter.md
@@ -1,0 +1,4 @@
+---
+theme: black
+
+# Broken

--- a/tests/fixtures/views/pages/slides/markdown/standalone-invalid-non-scalar.md
+++ b/tests/fixtures/views/pages/slides/markdown/standalone-invalid-non-scalar.md
@@ -1,0 +1,6 @@
+---
+theme:
+  - black
+---
+
+# Broken

--- a/tests/fixtures/views/pages/slides/markdown/standalone.md
+++ b/tests/fixtures/views/pages/slides/markdown/standalone.md
@@ -1,0 +1,23 @@
+---
+theme: black
+transition: fade
+highlight-theme: catppuccin-mocha
+show-controls: false
+---
+
+# Intro
+
+Welcome to SlideWire.
+
+<!-- slide -->
+
+---
+theme: white
+auto-slide: 3000
+---
+
+## Code
+
+```php
+echo 'Hello';
+```

--- a/tests/fixtures/views/pages/slides/team/q1-kickoff.blade.php
+++ b/tests/fixtures/views/pages/slides/team/q1-kickoff.blade.php
@@ -2,7 +2,8 @@
 
 use Livewire\Component;
 
-new class extends Component {
+new class() extends Component
+{
     //
 }; ?>
 
@@ -10,23 +11,7 @@ new class extends Component {
     <x-slidewire::slide class="bg-slate-900 text-white">
         <div class="mx-auto max-w-5xl space-y-6">
             <h1 class="text-4xl font-bold tracking-tight">Q1 Kickoff</h1>
-            <p class="text-lg text-slate-200">
-                Presentation key: <strong>team/q1-kickoff</strong>
-            </p>
-            <x-slidewire::fragment>
-                <p class="text-base text-slate-300">Use the arrow keys, click, or swipe to navigate.</p>
-            </x-slidewire::fragment>
-        </div>
-    </x-slidewire::slide>
-
-    <x-slidewire::slide class="bg-white text-slate-900">
-        <div class="mx-auto max-w-4xl space-y-6">
-            <x-slidewire::markdown>
-## Markdown Support
-
-- Write markdown directly in this single presentation file.
-- Combine markdown with Tailwind classes in each slide.
-            </x-slidewire::markdown>
+            <p class="text-lg text-slate-200">Presentation key: <strong>team/q1-kickoff</strong></p>
         </div>
     </x-slidewire::slide>
 </x-slidewire::deck>


### PR DESCRIPTION
SlideWire needs a larger authoring surface so presentations can scale from simple single-file decks to content-first Markdown decks and composed slide directories.

### Usage

```bash
php artisan make:slidewire team/q1-kickoff --md
php artisan make:slidewire team/q1-kickoff --multi
```

### Approach

- add resolver and compiler support for standalone Markdown presentations
- allow directory-backed decks to combine ordered Blade and Markdown slide parts
- extend scaffolding and test coverage so the new authoring formats stay stable