### PR TITLE
Fix slide offsets after repeated navigation

### DIFF
--- a/resources/views/livewire/presentation-deck.blade.php
+++ b/resources/views/livewire/presentation-deck.blade.php
@@ -218,6 +218,8 @@
                 leavingIndex: null,
                 isTransitioning: false,
                 transitionTimeout: null,
+                transitionToken: 0,
+                frameTransitionAnimations: new Map(),
                 autoSlideTimeout: null,
                 reducedMotionQuery: null,
                 init() {
@@ -709,6 +711,36 @@
                             });
                     });
                 },
+                resetFrameTransitionState(slide) {
+                    if (!slide) {
+                        return;
+                    }
+
+                    slide.style.opacity = '';
+                    slide.style.transform = '';
+                },
+                clearFrameTransition(slide) {
+                    if (!slide) {
+                        return;
+                    }
+
+                    const animation = this.frameTransitionAnimations.get(slide);
+
+                    if (animation) {
+                        animation.cancel();
+                        this.frameTransitionAnimations.delete(slide);
+                    }
+
+                    this.resetFrameTransitionState(slide);
+                },
+                startFrameTransition(slide, keyframes, options) {
+                    this.clearFrameTransition(slide);
+
+                    const animation = slide.animate(keyframes, options);
+                    this.frameTransitionAnimations.set(slide, animation);
+
+                    return animation;
+                },
                 playTransition(oldIndex, newIndex) {
                     if (oldIndex === undefined || oldIndex === null || oldIndex === newIndex) {
                         return;
@@ -722,6 +754,18 @@
 
                         return;
                     }
+
+                    const token = ++this.transitionToken;
+                    const previousLeavingSlide = this.leavingIndex !== null ? this.$refs[`slide${this.leavingIndex}`] : null;
+
+                    if (this.transitionTimeout) {
+                        window.clearTimeout(this.transitionTimeout);
+                        this.transitionTimeout = null;
+                    }
+
+                    this.clearFrameTransition(previousLeavingSlide);
+                    this.clearFrameTransition(fromSlide);
+                    this.clearFrameTransition(toSlide);
 
                     // Let auto-animate handle the transition to avoid overlap flicker.
                     if (this.shouldAutoAnimate(fromSlide, toSlide)) {
@@ -743,24 +787,43 @@
                     this.leavingIndex = oldIndex;
                     this.isTransitioning = true;
 
-                    if (this.transitionTimeout) {
-                        window.clearTimeout(this.transitionTimeout);
-                    }
+                    const completeTransition = () => {
+                        if (this.transitionToken !== token) {
+                            return;
+                        }
+
+                        if (this.transitionTimeout) {
+                            window.clearTimeout(this.transitionTimeout);
+                            this.transitionTimeout = null;
+                        }
+
+                        this.leavingIndex = null;
+                        this.isTransitioning = false;
+
+                        this.$nextTick(() => {
+                            this.clearFrameTransition(fromSlide);
+                            this.clearFrameTransition(toSlide);
+                        });
+                    };
 
                     if (transition === 'none') {
-                        this.transitionTimeout = window.setTimeout(() => {
-                            this.leavingIndex = null;
-                            this.isTransitioning = false;
-                        }, 20);
+                        this.transitionTimeout = window.setTimeout(completeTransition, 20);
 
                         return;
                     }
 
-                    const run = (el, keyframes) => el.animate(keyframes, {
-                        duration,
-                        easing,
-                        fill: 'both',
-                    });
+                    const animations = [];
+                    const run = (el, keyframes) => {
+                        const animation = this.startFrameTransition(el, keyframes, {
+                            duration,
+                            easing,
+                            fill: 'both',
+                        });
+
+                        animations.push(animation);
+
+                        return animation;
+                    };
 
                     if (transition === 'fade') {
                         run(fromSlide, [{ opacity: 1 }, { opacity: 0 }]);
@@ -797,10 +860,10 @@
                         }
                     }
 
-                    this.transitionTimeout = window.setTimeout(() => {
-                        this.leavingIndex = null;
-                        this.isTransitioning = false;
-                    }, duration + 25);
+                    Promise.allSettled(animations.map((animation) => animation.finished))
+                        .then(completeTransition);
+
+                    this.transitionTimeout = window.setTimeout(completeTransition, duration + 25);
                 },
                 toggleFullscreen() {
                     if (document.fullscreenElement) {

--- a/tests/Browser/PresentationNavigationBrowserTest.php
+++ b/tests/Browser/PresentationNavigationBrowserTest.php
@@ -4,6 +4,39 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 
+function slidewireActiveFrameMetrics($page): array
+{
+    return json_decode((string) $page->script(<<<'JS_WRAP'
+        (() => {
+            const frame = document.querySelector('.slidewire-frame.is-active');
+            const content = frame?.querySelector('.slidewire-content');
+            const frameRect = frame.getBoundingClientRect();
+            const contentRect = content.getBoundingClientRect();
+    
+            return JSON.stringify({
+                frameLeft: frameRect.left,
+                frameRight: frameRect.right,
+                viewportWidth: window.innerWidth,
+                contentCenter: contentRect.left + (contentRect.width / 2),
+                viewportCenter: window.innerWidth / 2,
+                animationCount: frame.getAnimations().length,
+                transform: getComputedStyle(frame).transform,
+                opacity: getComputedStyle(frame).opacity,
+            });
+        })()
+    JS_WRAP), true);
+}
+
+function expectSlidewireFrameAligned(array $metrics): void
+{
+    expect(abs($metrics['frameLeft']))->toBeLessThanOrEqual(2)
+        ->and(abs($metrics['frameRight'] - $metrics['viewportWidth']))->toBeLessThanOrEqual(2)
+        ->and(abs($metrics['contentCenter'] - $metrics['viewportCenter']))->toBeLessThanOrEqual(4)
+        ->and($metrics['animationCount'])->toBe(0)
+        ->and($metrics['transform'])->toBe('none')
+        ->and($metrics['opacity'])->toBe('1');
+}
+
 it('navigates a presentation in the browser', function (): void {
     if (! class_exists(Pest\Browser\Plugin::class)) {
         test()->markTestSkipped('Browser plugin is not installed in this environment.');
@@ -34,4 +67,106 @@ it('renders a vertical-slide presentation in the browser', function (): void {
     $page->waitForText('Horizontal Slide 1')
         ->assertSee('Horizontal Slide 1')
         ->assertNoJavaScriptErrors();
+})->group('browser');
+
+it('keeps the active frame aligned after repeated back and forward navigation', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/offset-regression', 'offset-regression');
+
+    $page = visit('/slides/offset-regression');
+
+    $page->resize(1624, 978)
+        ->waitForText('Offset Intro')
+        ->assertNoJavaScriptErrors();
+
+    expectSlidewireFrameAligned(slidewireActiveFrameMetrics($page));
+
+    foreach (range(1, 3) as $_) {
+        $page->script("document.querySelector('.slidewire-control-right').click()");
+        $page->wait(0.45);
+    }
+
+    $page->assertSee('Zoom Cards');
+    expectSlidewireFrameAligned(slidewireActiveFrameMetrics($page));
+
+    $page->script("document.querySelector('.slidewire-control-left').click()");
+    $page->wait(0.45);
+
+    $page->assertSee('Fade Metrics');
+    expectSlidewireFrameAligned(slidewireActiveFrameMetrics($page));
+
+    $page->script("document.querySelector('.slidewire-control-right').click()");
+    $page->wait(0.45);
+
+    $page->assertSee('Zoom Cards')
+        ->assertNoJavaScriptErrors();
+
+    expectSlidewireFrameAligned(slidewireActiveFrameMetrics($page));
+})->group('browser');
+
+it('keeps the active frame aligned after interrupted back and forward navigation', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/offset-regression-interrupted', 'offset-regression');
+
+    $page = visit('/slides/offset-regression-interrupted');
+
+    $page->resize(1624, 978)
+        ->waitForText('Offset Intro')
+        ->assertNoJavaScriptErrors();
+
+    $page->script("document.querySelector('.slidewire-control-right').click()");
+    $page->wait(0.06);
+    $page->script("document.querySelector('.slidewire-control-right').click()");
+    $page->wait(0.06);
+    $page->script("document.querySelector('.slidewire-control-left').click()");
+    $page->wait(0.06);
+    $page->script("document.querySelector('.slidewire-control-right').click()");
+    $page->wait(0.55);
+
+    $page->assertSee('Fade Metrics')
+        ->assertNoJavaScriptErrors();
+
+    expectSlidewireFrameAligned(slidewireActiveFrameMetrics($page));
+})->group('browser');
+
+it('keeps the active frame aligned after vertical navigation', function (): void {
+    if (! class_exists(Pest\Browser\Plugin::class)) {
+        test()->markTestSkipped('Browser plugin is not installed in this environment.');
+    }
+
+    config()->set('slidewire.presentation_roots', [__DIR__ . '/../fixtures/views/pages/slides']);
+
+    Route::slidewire('/slides/offset-regression-vertical', 'offset-regression');
+
+    $page = visit('/slides/offset-regression-vertical');
+
+    $page->resize(1624, 978)
+        ->waitForText('Offset Intro')
+        ->assertNoJavaScriptErrors();
+
+    foreach (range(1, 4) as $_) {
+        $page->script("document.querySelector('.slidewire-control-right').click()");
+        $page->wait(0.45);
+    }
+
+    $page->assertSee('Vertical Overview');
+    expectSlidewireFrameAligned(slidewireActiveFrameMetrics($page));
+
+    $page->script("document.querySelector('.slidewire-control-down').click()");
+    $page->wait(0.45);
+
+    $page->assertSee('Vertical Detail')
+        ->assertNoJavaScriptErrors();
+
+    expectSlidewireFrameAligned(slidewireActiveFrameMetrics($page));
 })->group('browser');

--- a/tests/fixtures/views/pages/slides/offset-regression.blade.php
+++ b/tests/fixtures/views/pages/slides/offset-regression.blade.php
@@ -1,0 +1,66 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component {
+    //
+}; ?>
+
+<x-slidewire::deck transition="slide" transition-duration="220" theme="black">
+    <x-slidewire::slide class="bg-slate-950 text-white">
+        <div style="display: grid; gap: 1rem; text-align: center;">
+            <p style="text-transform: uppercase; letter-spacing: .22em; color: #38bdf8;">Offset Regression</p>
+            <h1 style="font-size: clamp(3rem, 8vw, 8rem); margin: 0;">Offset Intro</h1>
+        </div>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide class="bg-slate-900 text-white">
+        <div style="display: grid; gap: 1.25rem;">
+            <h2 style="font-size: clamp(2.25rem, 5vw, 5.25rem); margin: 0;">Wide Grid</h2>
+            <div style="display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1rem;">
+                @foreach (range(1, 8) as $item)
+                    <div style="min-height: 8rem; border-radius: 1.25rem; padding: 1.25rem; background: rgba(14, 165, 233, .16); border: 1px solid rgba(125, 211, 252, .28);">
+                        <strong>Panel {{ $item }}</strong>
+                        <p>Dense content keeps this slide close to the showcase layout width.</p>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide transition="fade" class="bg-sky-950 text-white">
+        <div style="display: grid; gap: 1rem; text-align: center;">
+            <h2 style="font-size: clamp(2.5rem, 6vw, 6rem); margin: 0;">Fade Metrics</h2>
+            <p style="font-size: 1.5rem;">A non-slide transition must clean up frame opacity animations.</p>
+        </div>
+    </x-slidewire::slide>
+
+    <x-slidewire::slide transition="zoom" class="bg-indigo-950 text-white">
+        <div style="display: grid; grid-template-columns: 1.1fr .9fr; gap: 2rem; align-items: center;">
+            <div>
+                <h2 style="font-size: clamp(2.75rem, 7vw, 7rem); margin: 0;">Zoom Cards</h2>
+                <p style="font-size: 1.5rem;">The active frame should return to layout-owned transform state.</p>
+            </div>
+            <div style="display: grid; gap: 1rem;">
+                <div style="height: 9rem; border-radius: 1.5rem; background: rgba(129, 140, 248, .28);"></div>
+                <div style="height: 9rem; border-radius: 1.5rem; background: rgba(56, 189, 248, .22);"></div>
+            </div>
+        </div>
+    </x-slidewire::slide>
+
+    <x-slidewire::vertical-slide>
+        <x-slidewire::slide class="bg-emerald-950 text-white">
+            <div style="display: grid; gap: 1rem; text-align: center;">
+                <h2 style="font-size: clamp(2.5rem, 6vw, 6rem); margin: 0;">Vertical Overview</h2>
+                <p style="font-size: 1.5rem;">Horizontal entry to a vertical stack.</p>
+            </div>
+        </x-slidewire::slide>
+
+        <x-slidewire::slide class="bg-teal-950 text-white">
+            <div style="display: grid; gap: 1rem; text-align: center;">
+                <h2 style="font-size: clamp(2.5rem, 6vw, 6rem); margin: 0;">Vertical Detail</h2>
+                <p style="font-size: 1.5rem;">Vertical navigation must also clear translateY animations.</p>
+            </div>
+        </x-slidewire::slide>
+    </x-slidewire::vertical-slide>
+</x-slidewire::deck>

--- a/tests/fixtures/views/pages/slides/ui-components.blade.php
+++ b/tests/fixtures/views/pages/slides/ui-components.blade.php
@@ -69,7 +69,7 @@ new class() extends Component
         <div class="mx-auto flex min-h-full w-full max-w-5xl items-center">
             <x-slidewire::panel title="Meet the speaker" overline="Built from primitives" variant="elevated" tone="primary" class="w-full">
                 <div class="flex items-center gap-5">
-                    <img src="https://assets.example.test/avatars/1.webp" alt="Wendell Adriel" class="size-24 rounded-full object-cover outline-1 -outline-offset-1 outline-white/10" />
+                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 96 96'%3E%3Crect width='96' height='96' rx='48' fill='%230e7490'/%3E%3Ctext x='48' y='58' text-anchor='middle' font-size='32' font-family='Arial' fill='white'%3EWA%3C/text%3E%3C/svg%3E" alt="Wendell Adriel" class="size-24 rounded-full object-cover outline-1 -outline-offset-1 outline-white/10" />
                     <div class="space-y-2">
                         <h3 class="text-3xl font-semibold text-white">Wendell Adriel</h3>
                         <p class="text-sm/6 text-cyan-100/70">Maintainer - SlideWire</p>


### PR DESCRIPTION
Slide frames could keep stale Web Animations state after back/forward navigation, which left active slides visually offset in wide showcase layouts. This clears frame-level transition animations when transitions finish or get interrupted, while keeping element animations and auto-animate behavior separate.

Fixes #13